### PR TITLE
Use implicit namespace pkg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,7 @@ setup(
         'console_scripts': []
     },
     package_dir={'': 'src'},
-    packages=find_packages('src'),
-    namespace_packages=['crate'],
+    packages=['crate.qa'],
     install_requires=requirements().split('\n'),
     python_requires='>=3.6',
     classifiers=[

--- a/src/crate/__init__.py
+++ b/src/crate/__init__.py
@@ -1,7 +1,0 @@
-# namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)


### PR DESCRIPTION
See https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages

For some reasons I got errors running the tests otherwise:

    ImportError: Failed to import test module: startup.test_yaml
    Traceback (most recent call last):
    File "/usr/lib/python3.6/unittest/loader.py", line 428, in _find_test_path
        module = self._get_module_from_name(name)
    File "/usr/lib/python3.6/unittest/loader.py", line 369, in _get_module_from_name
        __import__(name)
    File "../crate/crate-qa/tests/startup/test_yaml.py", line 6, in <module>
        from crate.qa.tests import NodeProvider
    ModuleNotFoundError: No module named 'crate.qa'