### PR TITLE
Fix a race condition in the BwcTest

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -106,7 +106,7 @@ class BwcTest(NodeProvider, unittest.TestCase):
             cluster.start()
             with connect(cluster.node().http_url) as conn:
                 cursor = conn.cursor()
-                wait_for_active_shards(cursor)
+                wait_for_active_shards(cursor, 4)
                 cursor.execute('ALTER TABLE doc.t1 SET ("number_of_replicas" = 1)')
                 if upgrade_segments:
                     cursor.execute('OPTIMIZE TABLE doc.t1 WITH (upgrade_segments = true)')


### PR DESCRIPTION
The `wait_for_active_shards` method could return *before* any
shards/tables had been recovered. This could cause the next `alter
table` statement to fail with a `SchemaUnknownException`