### PR TITLE
Add wait_for_active_shards after replica change in BWC tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+cache: pip
+python:
+    - 3.6
+    - nightly
+
+before_install:
+    - pip install --upgrade setuptools
+    - pip uninstall -y six
+
+install:
+    - pip install --upgrade -e .
+
+script:
+    - cd tests && python -m unittest -vvv
+
+notifications:
+    email: false
+
+sudo: false
+addons:
+  apt:
+    packages:
+      - oracle-java8-set-default
+
+matrix:
+    allow_failures:
+        - python: nightly

--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -114,4 +114,5 @@ class BwcTest(NodeProvider, unittest.TestCase):
                 blobs = conn.get_blob_container('b1')
                 run_selects(cursor, blobs, digest)
                 cursor.execute('ALTER TABLE doc.t1 SET ("number_of_replicas" = 0)')
+                wait_for_active_shards(cursor, 4)
             self._process_on_stop()


### PR DESCRIPTION
Should fix an occasional TimeoutError on `wait_for_active_shards`