### PR TITLE
Fix timeout error in BwcTest

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -107,11 +107,11 @@ class BwcTest(NodeProvider, unittest.TestCase):
             with connect(cluster.node().http_url) as conn:
                 cursor = conn.cursor()
                 wait_for_active_shards(cursor, 4)
-                cursor.execute('ALTER TABLE doc.t1 SET ("number_of_replicas" = 1)')
                 if upgrade_segments:
                     cursor.execute('OPTIMIZE TABLE doc.t1 WITH (upgrade_segments = true)')
                     cursor.execute('OPTIMIZE TABLE blob.b1 WITH (upgrade_segments = true)')
+                cursor.execute('ALTER TABLE doc.t1 SET ("refresh_interval" = 4000)')
                 blobs = conn.get_blob_container('b1')
                 run_selects(cursor, blobs, digest)
-                cursor.execute('ALTER TABLE doc.t1 SET ("number_of_replicas" = 0)')
+                cursor.execute('ALTER TABLE doc.t1 SET ("refresh_interval" = 2000)')
             self._process_on_stop()


### PR DESCRIPTION
Sometimes the `upgrade_segments` operation didn't work correctly.
`wait_for_active_shards` would timeout in `2.x` because a shard
contained old segment files that were no longer readable.

It seems that changing the number_of_replicas somehow caused this.
It's still unclear why - but since we cannot fix this back in 1.1 we'll
have to do a workaround here.

It also seems to be a race-condition, not something that is generally
broken.