### PR TITLE
Exclude `col_ip` query when running against 2.0 or 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 language: python
 cache: pip
 python:
-    - 3.6
+  - 3.6
 
 before_install:
-    - pip install --upgrade setuptools
-    - pip uninstall -y six
-    - sync && echo 3 | sudo tee /proc/sys/vm/drop_caches # https://github.com/elastic/elasticsearch/issues/28650
+  - pip install --upgrade setuptools
+  - pip uninstall -y six
+  - sync && echo 3 | sudo tee /proc/sys/vm/drop_caches  # https://github.com/elastic/elasticsearch/issues/28650
 
 install:
-    - pip install --upgrade -e .
-    - pip install crash
+  - pip install --upgrade -e .
+  - pip install crash
 
 script:
-    - tests/client_tests/go/run.sh
-    - cd tests && python -m unittest -vvv $(find . -name "test_*.py" | grep -v test_upgrade.py | xargs readlink -f)
+  - tests/client_tests/go/run.sh
+  - cd tests && python -m unittest -vvv $(find . -name "test_*.py" | grep -v test_upgrade.py | xargs readlink -f)
 
 env:
   - DEBUG=false
 
 notifications:
-    email: false
+  email: false
 
 sudo: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - sync && echo 3 | sudo tee /proc/sys/vm/drop_caches # https://github.com/elastic/elasticsearch/issues/28650
 
 install:
-    - pip install --upgrade --process-dependency-links -e .
+    - pip install --upgrade -e .
     - pip install crash
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import functools
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 def read(filename):
@@ -30,12 +30,9 @@ setup(
     packages=['crate.qa'],
     namespace_packages=['crate'],
     install_requires=[
-        'cr8==0.12-master',
+        'cr8',
         'Cython',
         'asyncpg'
-    ],
-    dependency_links=[
-        'git+https://github.com/mfussenegger/cr8.git@master#egg=cr8-0.12-master',
     ],
     python_requires='>=3.6',
     classifiers=[

--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -1,8 +1,7 @@
 import unittest
 from io import BytesIO
 from crate.client import connect
-from crate.client.cursor import Cursor
-from crate.client.connection import Connection
+from crate.client.exceptions import ProgrammingError
 from crate.qa.tests import VersionDef, NodeProvider, \
     wait_for_active_shards, insert_data, gen_id
 
@@ -89,7 +88,10 @@ SELECT_STATEMENTS = (
 
 def run_selects(c, blob_container, digest):
     for stmt in SELECT_STATEMENTS:
-        c.execute(stmt)
+        try:
+            c.execute(stmt)
+        except ProgrammingError as e:
+            raise ProgrammingError('Error executing ' + stmt) from e
     blob_container.get(digest)
 
 


### PR DESCRIPTION
It was broken in these versions