### PR TITLE
Added tests to verify DEALLOCATE stmt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 
 script:
   - tests/client_tests/go/run.sh
+  - tests/client_tests/php/run.sh
   - find tests -name "*.py" | xargs mypy --ignore-missing-imports
   - find src -name "*.py" | xargs mypy --ignore-missing-imports
   - cd tests && python -m unittest -vvv $(find . -name "test_*.py" | grep -v test_upgrade.py | xargs readlink -f)

--- a/tests/client_tests/php/run.sh
+++ b/tests/client_tests/php/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cr8 run-crate latest-nightly \
+    -- @php $(dirname "$0")/test_deallocate.php \
+            '{node.addresses.psql.host}' \
+            '{node.addresses.psql.port}' 
+

--- a/tests/client_tests/php/test_deallocate.php
+++ b/tests/client_tests/php/test_deallocate.php
@@ -1,0 +1,43 @@
+#!/usr/bin/env php
+<?php
+
+if ($argc != 3) {
+	echo "Provide both host and port of CrateDB";
+	exit(1);
+} 
+$host = $argv[1];
+$port = $argv[2];
+
+if (empty($host) || empty($port)) {
+    echo "Provide both host and port of CrateDB";
+	exit(1);
+}
+
+$pdo = new PDO('pgsql:dbname=doc;user=crate;host='.$host.';port='.$port);
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$stmt = $pdo->query("select name from sys.cluster");
+while ($row = $stmt->fetch()) {
+	echo "Cluster name: ".$row['name']."\n";
+}
+
+$stmt = $pdo->prepare("create table t1 (x int)");
+$stmt->execute();
+
+$stmt = $pdo->prepare("insert into t1 (x) values (?)");
+$stmt->execute([1]);
+
+$stmt = $pdo->prepare("insert into t1 (x) values (:val)");
+$stmt->bindValue(':val', 2);
+$stmt->execute();
+
+$pdo->prepare("refresh table t1")->execute();
+$stmt = NULL;
+
+$count = $pdo->query("select count(x) from t1")->fetch()['count(x)'];
+if ($count != 2) {
+	echo "Wrong result:{$count}, expected: 2";
+	exit(1);
+}
+
+?> 


### PR DESCRIPTION
By using PHP's PDO/libpq we make sure that DEALLOCATE <prep_stmt_name>
statement are invoked and CrateDB handles them correctly.