### PR TITLE
Re-enable nightly version for testing upgrade paths.

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -28,6 +28,7 @@ UPGRADE_PATHS = (
         VersionDef('2.2.x', False),
         VersionDef('2.3.x', True),
         VersionDef('3.0.3', False),
+        VersionDef('latest-nightly', False),
     ),
 )
 


### PR DESCRIPTION
A nightly build with the fix is available.
followup to 479d133cf3ac5bb92ab7bc7077c7c28fa28e966d