### PR TITLE
bwc: Test 3.0.x again instead of 3.0.3

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -27,7 +27,7 @@ UPGRADE_PATHS = (
         VersionDef('2.1.x', False),
         VersionDef('2.2.x', False),
         VersionDef('2.3.x', True),
-        VersionDef('3.0.3', False),
+        VersionDef('3.0.x', False),
         VersionDef('latest-nightly', False),
     ),
 )


### PR DESCRIPTION
We've a tarball for 3.0.5 with a fix for the BWC issue.