### PR TITLE
Nail Faker to latest 0.8.x version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
     install_requires=[
         'cr8',
         'Cython',
-        'asyncpg'
+        'asyncpg',
+        'Faker==0.8.18'
     ],
     python_requires='>=3.6',
     classifiers=[


### PR DESCRIPTION
0.9.0 contains changes that require cr8 to be adapted first.

Behavior is broken by: https://github.com/joke2k/faker/commit/f1653f2c4c9789cc940acf26d49e6ac8eaa5c933#diff-b944d78c99f7307469fdcefdb81c84e3 and cr8 must be adapted appropriately.