### PR TITLE
Add `unixodbc` dev packages to odbc installation documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Examples:
 
 Apt:
 
-`apt-get install odbc-postgresql`
+`apt-get install odbc-postgresql unixodbc-dev`
 
 Yum:
 
-`yum install postgresql-odbc`
+`yum install postgresql-odbc unixODBC-devel`
 
 
 ## Test Suites


### PR DESCRIPTION
pyodbc requires the unixodbc headers for building.