### PR TITLE
Remove upgrade tests from 0.54 to 2.3

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -11,18 +11,6 @@ from crate.qa.tests import VersionDef, NodeProvider, \
 
 UPGRADE_PATHS = (
     (
-        VersionDef('0.54.x', False),
-        VersionDef('0.55.x', False),
-        VersionDef('0.56.x', False),
-        VersionDef('0.57.x', False),
-        VersionDef('1.0.x', False),
-        VersionDef('1.1.x', True),
-        VersionDef('2.0.x', False),
-        VersionDef('2.1.x', False),
-        VersionDef('2.2.x', False),
-        VersionDef('2.3.x', False),
-    ),
-    (
         VersionDef('2.0.x', False),
         VersionDef('2.1.x', False),
         VersionDef('2.2.x', False),


### PR DESCRIPTION
We're not making any changes anymore to these releases, so we don't have
to test them.