### PR TITLE
Lock asyncpg version to avoid test failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         'cr8>=0.14.0',
         'Cython',
-        'asyncpg',
+        'asyncpg<=0.17.0',
         'pyodbc'
     ],
     python_requires='>=3.6',

--- a/tests/client_tests/python/asyncpg/test_asyncpg.py
+++ b/tests/client_tests/python/asyncpg/test_asyncpg.py
@@ -4,76 +4,49 @@ import unittest
 from crate.qa.tests import NodeProvider
 
 
+async def exec_queries(test, hosts):
+    pool = await asyncpg.create_pool(f'postgres://crate@{hosts}/doc')
+    async with pool.acquire() as conn:
+        result = await conn.execute(
+            "CREATE TABLE t1 (x int primary key, y int)")
+        test.assertEqual(result, 'CREATE 1')
+
+        result = await conn.execute('INSERT INTO t1 (x) VALUES (?)', 1)
+        test.assertEqual(result, 'INSERT 0 1')
+
+        result = await conn.execute('REFRESH TABLE t1')
+        test.assertEqual(result, 'REFRESH 1')
+
+        result = await conn.execute('UPDATE t1 SET y = ?', 2)
+        test.assertEqual(result, 'UPDATE 1')
+
+        result = await conn.execute('REFRESH TABLE t1')
+        test.assertEqual(result, 'REFRESH 1')
+
+        result = await conn.execute('DELETE FROM t1 WHERE y = ?', 2)
+        test.assertEqual(result, 'DELETE 1')
+
+        result = await conn.execute('''
+            INSERT INTO t1 (x) (
+                SELECT col1 FROM unnest([1, 2]) WHERE col1 = ?
+            )
+        ''', 1)
+        test.assertEqual(result, 'INSERT 0 1')
+
+        result = await conn.execute('''
+            INSERT INTO t1 (x) (
+                SELECT col1 FROM unnest([1, 2]) WHERE col1 = ?)
+            ON CONFLICT (x) DO UPDATE SET y = ?
+        ''', 1, 2)
+        test.assertEqual(result, 'INSERT 0 1')
+
+
 class AsyncpgTestCase(NodeProvider, unittest.TestCase):
 
     def test_basic_statements(self):
         (node, _) = self._new_node(self.CRATE_VERSION)
         node.start()
-
-        async def run(hosts, future):
-            pool = await asyncpg.create_pool(f'postgres://crate@{hosts}/doc')
-            async with pool.acquire() as conn:
-                try:
-                    create_result = await conn.execute("CREATE TABLE t1 (x int \
-                            primary key, y int)")
-                    if int(create_result[7]) != 1:
-                        future.set_exception(AssertionError("CREATE statement \
-should've returned count 1 but the result was: " + create_result))
-
-                    insert_result = await conn.execute('INSERT INTO t1(x) VALUES(?)', 1)
-                    if int(insert_result[9]) != 1:
-                        future.set_exception(AssertionError("INSERT statement \
-should've returned count 1 but the result was: " + insert_result))
-
-                    refresh_result = await conn.execute('REFRESH TABLE t1')
-                    if int(refresh_result[8]) != 1:
-                        future.set_exception(AssertionError("REFRESH statement \
-should've returned count 1 but the result was: " + refresh_result))
-
-                    update_result = await conn.execute('UPDATE t1 SET y = ?', 2)
-                    if int(update_result[7]) != 1:
-                        future.set_exception(AssertionError("UPDATE statement \
-should've returned count 1 but the result was: " + update_result))
-
-                    refresh_result = await conn.execute('REFRESH TABLE t1')
-                    if int(refresh_result[8]) != 1:
-                        future.set_exception(AssertionError("REFRESH statement \
-should've returned count 1 but the result was: " + refresh_result))
-
-                    delete_result = await conn.execute('DELETE FROM t1 WHERE y = ?', 2)
-                    if int(delete_result[7]) != 1:
-                        future.set_exception(AssertionError("DELETE statement \
-should've returned count 1 but the result was: " + delete_result))
-
-                    insert_from_subquery_result = await conn.execute('INSERT INTO \
-                            t1 (x) (SELECT col1 FROM unnest([1, 2]) WHERE col1 = ?)', 1)
-                    if int(insert_from_subquery_result[9]) != 1:
-                        future.set_exception(AssertionError("INSERT FROM SUBQUERY \
-should've returned count 1 but the result was: " + insert_from_subquery_result))
-
-                    insert_subquery_on_duplicate = await conn.execute('INSERT INTO \
-                            t1 (x) (SELECT col1 FROM unnest([1, 2]) \
-                            WHERE col1 = ?) ON DUPLICATE KEY UPDATE y = ?', 1, 2)
-                    if int(insert_subquery_on_duplicate[9]) != 1:
-                        future.set_exception(AssertionError("INSERT FROM SUBQUERY \
-with ON DUPLICATE KEY clause should've returned count 1 but the result was:\
-" + insert_subquery_on_duplicate))
-
-                    if not future.done():
-                        future.set_result("Success!")
-
-                except Exception as e:
-                    future.set_exception(e)
-
-                finally:
-                    # Close the connection.
-                    await conn.close()
-
         loop = asyncio.get_event_loop()
-        future = asyncio.Future()
-        psql_protocol = node.addresses.psql
-        crate_psql_url = str(psql_protocol.host) + ':' + \
-            str(psql_protocol.port)
-        asyncio.ensure_future(run(crate_psql_url, future))
-        loop.run_until_complete(future)
-        print(future.result())
+        psql_addr = node.addresses.psql
+        crate_psql_url = f'{psql_addr.host}:{psql_addr.port}'
+        loop.run_until_complete(exec_queries(self, crate_psql_url))


### PR DESCRIPTION
This is temporarily to get the tests to pass until the root cause is
fixed.