### PR TITLE
Changed default-template bwc test to test the upgrade from 2.1.x

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -291,7 +291,7 @@ class DefaultTemplateMetaDataCompatibilityTest(NodeProvider, unittest.TestCase):
     }
 
     SUPPORTED_VERSIONS = (
-        '1.1.x',
+        '2.1.x',
         'latest-nightly',
     )
 


### PR DESCRIPTION
Upgrading from 1.1.x to the latest nightly (3.2-snapshot) is not supported
because of the incompatible index formats (indices must be recreated).