### PR TITLE
Fix flaky BWC settings test

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -382,6 +382,7 @@ class TableSettingsCompatibilityTest(NodeProvider, unittest.TestCase):
             cursor.execute('''
                 INSERT INTO p1 (id, p) VALUES (1, 1);
             ''')
+            wait_for_active_shards(cursor, 8)
         self._process_on_stop()
 
         for version in self.SUPPORTED_VERSIONS[1:]:


### PR DESCRIPTION
Wait until shards are active before shutting down the initial version.
This should prevent shards to be reallocated on a new cluster start
and thus should decrease wait time until the shards on the new cluster
version are active (prevents to run into 60s timeout).

Related failure https://jenkins.crate.io/blue/organizations/jenkins/CrateDB%2Fqa%2Fcrate-qa/detail/crate-qa/504/pipeline.