### PR TITLE
Fix log4j2 config used in test_read_crate_yml

### DIFF
--- a/tests/startup/log4j2_console.properties
+++ b/tests/startup/log4j2_console.properties
@@ -44,7 +44,7 @@ appender.consoleOut.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]
 appender.consoleOut.filter.threshold.type = ThresholdFilter
 appender.consoleOut.filter.threshold.level = warn
 appender.consoleOut.filter.threshold.onMatch = DENY
-appender.consoleOut.filter.threshold.onMisMatch = ACCEPT
+appender.consoleOut.filter.threshold.onMismatch = ACCEPT
 
 # configure stderr
 appender.consoleErr.type = Console
@@ -56,5 +56,5 @@ appender.consoleErr.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]
 appender.consoleErr.filter.threshold.type = ThresholdFilter
 appender.consoleErr.filter.threshold.level = warn
 appender.consoleErr.filter.threshold.onMatch = ACCEPT
-appender.consoleErr.filter.threshold.onMisMatch = DENY
+appender.consoleErr.filter.threshold.onMismatch = DENY
 


### PR DESCRIPTION
Since
https://github.com/crate/crate/commit/2dc777139a10761f6cc195efdcb770a705f3da2f
errors in the logging configuration cause CrateDB to exit on startup.