### PR TITLE
Add support for CrateDB >= 4.0.0

### DIFF
--- a/src/crate/qa/tests.py
+++ b/src/crate/qa/tests.py
@@ -53,6 +53,13 @@ def test_settings(version: V) -> Dict[str, Any]:
     return s
 
 
+def remove_unsupported_settings(version: V, settings: dict) -> Dict[str, Any]:
+    new_settings = dict(settings)
+    if version >= V('4.0.0'):
+        new_settings.pop('license.enterprise', None)
+    return new_settings
+
+
 def version_tuple_to_strict_version(version_tuple: tuple) -> V:
     return V('.'.join([str(v) for v in version_tuple]))
 
@@ -214,6 +221,7 @@ class NodeProvider:
             }
             s.update(settings or {})
             s.update(test_settings(v))
+            s = remove_unsupported_settings(v, s)
             e = {
                 'CRATE_HEAP_SIZE': self.CRATE_HEAP_SIZE,
                 'CRATE_HOME': crate_dir,

--- a/tests/restart/test_metadata.py
+++ b/tests/restart/test_metadata.py
@@ -125,16 +125,16 @@ class MetadataTestCase(NodeProvider, unittest.TestCase):
                               ['s', 'v2']])
 
             cursor.execute("""
-            SELECT table_name, column_name, data_type
+            SELECT table_name, column_name
             FROM information_schema.columns
             WHERE table_name IN ('v1', 'v2')
-            ORDER BY table_name, column_name, data_type
+            ORDER BY table_name, column_name
             """)
             result = cursor.fetchall()
             self.assertEqual(result,
-                             [['v1', 'ts', 'timestamp'],
-                              ['v1', 'value', 'float'],
-                              ['v2', 'day', 'timestamp'],
-                              ['v2', 'ts', 'timestamp'],
-                              ['v2', 'type', 'short'],
-                              ['v2', 'value', 'float']])
+                             [['v1', 'ts'],
+                              ['v1', 'value'],
+                              ['v2', 'day'],
+                              ['v2', 'ts'],
+                              ['v2', 'type'],
+                              ['v2', 'value']])

--- a/tests/startup/test_cli.py
+++ b/tests/startup/test_cli.py
@@ -1,9 +1,11 @@
 import os
 import unittest
 from pathlib import Path
+
+from distutils.version import StrictVersion as V
 from crate.client import connect
 from crate.client.exceptions import ProgrammingError
-from crate.qa.tests import NodeProvider
+from crate.qa.tests import NodeProvider, version_tuple_to_strict_version
 from faker import Faker
 from faker.config import AVAILABLE_LOCALES
 from faker.generator import random
@@ -77,7 +79,12 @@ class StartupTest(NodeProvider, unittest.TestCase):
             'auth.host_based.config.0.protocol': 'http',
         })
 
-        (node, _) = self._new_node(self.CRATE_VERSION, settings=settings)
+        (node, version_tuple) = self._new_node(self.CRATE_VERSION, settings=settings)
+        v = version_tuple_to_strict_version(version_tuple)
+        if v >= V('4.0.0'):
+            # disable/enable enterprise functionality is not possible anymore from version 4.0.0 on
+            return
+
         node.start()
 
         self._assert_enterprise_equal(node, True)
@@ -113,7 +120,12 @@ class StartupTest(NodeProvider, unittest.TestCase):
             'license.enterprise': False,
         })
 
-        (node, _) = self._new_node(self.CRATE_VERSION, settings=settings)
+        (node, version_tuple) = self._new_node(self.CRATE_VERSION, settings=settings)
+        v = version_tuple_to_strict_version(version_tuple)
+        if v >= V('4.0.0'):
+            # disable/enable enterprise functionality is not possible anymore from version 4.0.0 on
+            return
+
         node.start()
 
         self._assert_enterprise_equal(node, False)


### PR DESCRIPTION
- Remove unsupported settings on node start

- Remove column type assertion from view test
  Default column type names changed in CrateDB 4.0.0, asserting for
  the types is not required by the test.

- Don't run enterprise enabled/disabled test on >= 4.0.0
  The `license.enterprise` setting was removed on 4.0.0, it is not
  possible to disable/enable enterprise features anymore in favour
  of a seperate community edition.