### PR TITLE
Fix test_metadata_compatibility

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -258,6 +258,7 @@ class MetaDataCompatibilityTest(NodeProvider, unittest.TestCase):
 
     SUPPORTED_VERSIONS = (
         VersionDef('2.3.x', False, []),
+        VersionDef('3.3.x', False, []),
         VersionDef('latest-nightly', False, [])
     )
 


### PR DESCRIPTION
This adds `3.3.x` between 2.3 and latest-nightly so that migration logic
on templates is run. Otherwise the test would fail with:

    IllegalArgumentException: Index patterns must not be null or empty;
    got null