### PR TITLE
Remove 2.0 → 3.3 upgrade path tests

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -150,12 +150,11 @@ class StorageCompatibilityTest(NodeProvider, unittest.TestCase):
 
     def test_upgrade_paths(self):
         for path in get_test_paths():
-            with self.subTest(path_repr(path)):
-                try:
-                    self.setUp()
-                    self._test_upgrade_path(path, nodes=3)
-                finally:
-                    self.tearDown()
+            try:
+                self.setUp()
+                self._test_upgrade_path(path, nodes=3)
+            finally:
+                self.tearDown()
 
     def _upgrade(self, cursor, upgrade_segments, num_retries=3):
         """

--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -14,21 +14,10 @@ from crate.qa.tests import (
     insert_data,
     gen_id,
     prepare_env,
-    JDK_8_JAVA_HOME_CANDIDATES
 )
 
 
 UPGRADE_PATHS = (
-    (
-        VersionDef('2.0.x', False, JDK_8_JAVA_HOME_CANDIDATES),
-        VersionDef('2.1.x', False, JDK_8_JAVA_HOME_CANDIDATES),
-        VersionDef('2.2.x', False, JDK_8_JAVA_HOME_CANDIDATES),
-        VersionDef('2.3.x', True, []),
-        VersionDef('3.0.x', False, []),
-        VersionDef('3.1.x', False, []),
-        VersionDef('3.2.x', False, []),
-        VersionDef('3.3.x', False, []),
-    ),
     (
         VersionDef('3.0.x', False, []),
         VersionDef('3.1.x', False, []),


### PR DESCRIPTION
For some reason the 2.0 -> 2.1 upgrade path test is sometimes flaky.
Given that these version have been EOL for a long time this simply drops
the test scenario.