### PR TITLE
Nail asyncpg to < 0.20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         'cr8>=0.16.0',
         'Cython',
-        'asyncpg>=0.18.2',
+        'asyncpg>=0.18.2, < 0.20',
         'pyodbc',
         'psycopg2-binary==2.7.5'
     ],


### PR DESCRIPTION
With asyncpg 0.20 the tests get stuck.
This gets the tests to pass until we've figured out the root cause of
the asyncpg 0.20 issue