### PR TITLE
Add bwc tests for returning clause for update query

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
           agent { label 'medium' }
           steps {
             checkout scm
+            sh 'rm -rf env'
             sh '/usr/bin/python3.7 -m venv env'
             sh 'env/bin/python -m pip install -U mypy flake8'
             sh 'find tests -name "*.py" | xargs env/bin/mypy --ignore-missing-imports'
@@ -22,6 +23,7 @@ pipeline {
           steps {
             checkout scm
             sh '''
+              rm -rf env
               /usr/bin/python3.7 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
@@ -38,6 +40,7 @@ pipeline {
           steps {
             checkout scm
             sh '''
+              rm -rf env
               /usr/bin/python3.7 -m venv env
               source env/bin/activate
               python -m pip install -U cr8 crash
@@ -51,6 +54,7 @@ pipeline {
           steps {
             checkout scm
             sh '''
+              rm -rf env
               /usr/bin/python3.7 -m venv env
               source env/bin/activate
               python -m pip install -U cr8


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This adds a backward compatibility test when using update with returning clause  in a mixed cluster of 4.1 and 4.2 nodes. This test ensures that the previous functionality from 4.1 for update is fully working when a 4.2 node is in the cluster. It also ensures that the use of a returning clause from a 4.2 node yields a meaningful error when used in a cluster with 4.1 nodes.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
