### PR TITLE
Use newest node-postgres version

### DIFF
--- a/tests/client_tests/node-postgres/README.rst
+++ b/tests/client_tests/node-postgres/README.rst
@@ -8,6 +8,7 @@ Staring the node-postgres_ module as middleware.
 
 Run it like:
 
+- `npm install` (required once, to fetch the dependencies)
 - `node app.js <host> <port>` (requires **CrateDB** to be running on <host>:<port>).
 - `./run.sh` (takes care of running **CrateDB** by means of cr8_).
 

--- a/tests/client_tests/node-postgres/package-lock.json
+++ b/tests/client_tests/node-postgres/package-lock.json
@@ -69,11 +69,6 @@
         "optimist": "x"
       }
     },
-    "assert-options": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.6.0.tgz",
-      "integrity": "sha512-xmBFb5sY0AO8SNihIfavR6uMhOyzq6D7RoFKJxxAditMQc876szBBQ9RQVwLi6Bm3zUoG0nexZK11Gy5TBX69A=="
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -265,11 +260,6 @@
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
       "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
     },
-    "manakin": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/manakin/-/manakin-0.5.2.tgz",
-      "integrity": "sha512-pfDSB7QYoVg0Io4KMV9hhPoXpj6p0uBscgtyUSKCOFZe8bqgbpStfgnKIbF/ulnr6U3ICu4OqdyxAqBgOhZwBQ=="
-    },
     "memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -418,15 +408,15 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pg": {
-      "version": "7.17.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.17.1.tgz",
-      "integrity": "sha512-SYWEip6eADsgDQIZk0bmB2JDOrC8Xu6z10KlhlXl03NSomwVmHB6ZTVyDCwOfT6bXHI8QndJdk5XxSSRXikaSA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.1.tgz",
+      "integrity": "sha512-1KtKBKg/zWrjEEv//klBbVOPGucuc7HHeJf6OEMueVcUeyF3yueHf+DvhVwBjIAe9/97RAydO/lWjkcMwssuEw==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
         "pg-packet-stream": "^1.1.0",
-        "pg-pool": "^2.0.9",
+        "pg-pool": "^2.0.10",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
@@ -442,48 +432,15 @@
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
-    "pg-minify": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.5.1.tgz",
-      "integrity": "sha512-nqUTo8y9T0VhiJoWC0sK0+2S8hYDiu7CdH0Z9ijPi2iikiQ44mfcAFxEJxfvF8H3h/bDBvXthtOQPIB3pLWIow=="
-    },
     "pg-packet-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
       "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
     },
     "pg-pool": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.9.tgz",
-      "integrity": "sha512-gNiuIEKNCT3OnudQM2kvgSnXsLkSpd6mS/fRnqs6ANtrke6j8OY5l9mnAryf1kgwJMWLg0C1N1cYTZG1xmEYHQ=="
-    },
-    "pg-promise": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.3.5.tgz",
-      "integrity": "sha512-cdgrDKMDYk5daTTYqHsXiPfyfyeNF2T146jZZeMO9Q2GqhC5QAtsVNnGuEsAbU9VuSTassNOt7JRy0vwa17r2g==",
-      "requires": {
-        "assert-options": "0.6.0",
-        "manakin": "0.5.2",
-        "pg": "7.14.0",
-        "pg-minify": "1.5.1",
-        "spex": "3.0.0"
-      },
-      "dependencies": {
-        "pg": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/pg/-/pg-7.14.0.tgz",
-          "integrity": "sha512-TLsdOWKFu44vHdejml4Uoo8h0EwCjdIj9Z9kpz7pA5i8iQxOTwVb1+Fy+X86kW5AXKxQpYpYDs4j/qPDbro/lg==",
-          "requires": {
-            "buffer-writer": "2.0.0",
-            "packet-reader": "1.0.0",
-            "pg-connection-string": "0.1.3",
-            "pg-pool": "^2.0.7",
-            "pg-types": "^2.1.0",
-            "pgpass": "1.x",
-            "semver": "4.3.2"
-          }
-        }
-      }
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -615,11 +572,6 @@
       "requires": {
         "memory-pager": "^1.0.2"
       }
-    },
-    "spex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spex/-/spex-3.0.0.tgz",
-      "integrity": "sha512-JoMfgbrJcEPn53JCLkSNH1o7fZ9rzkb24UKEt5LTcsp0YsaN+yxtb5MEmibbMRltj9CdXDNGitPrYi11JY2hog=="
     },
     "split": {
       "version": "1.0.1",

--- a/tests/client_tests/node-postgres/package.json
+++ b/tests/client_tests/node-postgres/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "app": "^0.1.0",
-    "pg": "^7.17.1",
+    "pg": ">7.17.1",
     "uuid": "^3.4.0",
     "chai": "^4.2.0",
     "csv-parser": "^2.3.2"


### PR DESCRIPTION
This makes the dependency requirement on `pg` less restrictive, instead
of nailing to `7.17.1` it will use the latest version.

So we notice if upstream changes cause incompatibilities with CrateDB.