### PR TITLE
Select record type in asyncpg tests

### DIFF
--- a/tests/client_tests/python/asyncpg/test_asyncpg.py
+++ b/tests/client_tests/python/asyncpg/test_asyncpg.py
@@ -40,6 +40,10 @@ async def exec_queries(test, hosts):
         ''', 1, 2)
         test.assertEqual(result, 'INSERT 0 1')
 
+        result = await conn.fetch('SELECT pg_catalog.pg_get_keywords()')
+        keyword = sorted([row[0] for row in result], key=lambda x: x[0])[0]
+        test.assertEqual(keyword, ('add', 'R', 'reserved'))
+
 
 async def fetch_summits(test, host, port):
     conn = await asyncpg.connect(


### PR DESCRIPTION
To verify that binary streaming of record types works with CrateDB

(JDBC switches to text-streaming for records, so we don't have proper
integration tests for that in CrateDB itself)

This needs an update after a nightly with the RowType is out.