### PR TITLE
Add integration test for kafka-j

### DIFF
--- a/tests/kafka-connect-jdbc/README.md
+++ b/tests/kafka-connect-jdbc/README.md
@@ -1,0 +1,60 @@
+Launch Zookeeper, Kafka, schema-registry, kafka-connect and CrateDB:
+
+
+```
+$ docker-compose up
+```
+
+
+Create a table:
+
+
+```
+crash --hosts localhost:4200 <<EOF
+  create table metrics (id int primary key, x int);
+EOF
+
+```
+
+
+Configure a JDBC sink.
+
+Inserts only:
+
+```bash
+http PUT localhost:8083/connectors/jdbc-sink-connector/config \
+  connector.class="io.confluent.connect.jdbc.JdbcSinkConnector" \
+  topics='metrics' \
+  connection.url='jdbc:postgresql://localhost:5432/doc?user=crate' \
+  tasks.max=1
+```
+
+
+With Upsert:
+
+```bash
+http PUT localhost:8083/connectors/jdbc-sink-connector/config \
+  connector.class="io.confluent.connect.jdbc.JdbcSinkConnector" \
+  topics='metrics' \
+  connection.url='jdbc:postgresql://cratedb:5432/doc?user=crate' \
+  tasks.max=1 \
+  pk.mode=record_key \
+  pk.fields=id \
+  insert.mode=upsert
+```
+
+
+See [Sink connector options](https://docs.confluent.io/current/connect/kafka-connect-jdbc/sink-connector/sink_config_options.html#sink-pk-config-options for further options)
+
+
+Insert some data into Kafka:
+
+[JSON with schema](https://rmoff.net/2017/09/06/kafka-connect-jsondeserializer-with-schemas.enable-requires-schema-and-payload-fields/):
+
+
+```bash
+kafkacat -b localhost:9092 -t metrics -K "|" -P <<EOF
+1|{"schema": {"type": "struct", "fields": [{"type": "int32", "field": "id"}, {"type": "int32", "field": "x"}]}, "payload": {"id": 1, "x": 45}}
+2|{"schema": {"type": "struct", "fields": [{"type": "int32", "field": "id"}, {"type": "int32", "field": "x"}]}, "payload": {"id": 2, "x": 20}}
+EOF
+```

--- a/tests/kafka-connect-jdbc/docker-compose.yml
+++ b/tests/kafka-connect-jdbc/docker-compose.yml
@@ -1,0 +1,82 @@
+---
+version: '3.7'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.4.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker:
+    image: confluentinc/cp-kafka:5.4.0
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "29092:29092"
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:5.4.0
+    hostname: schema-registry
+    container_name: schema-registry
+    depends_on:
+      - zookeeper
+      - broker
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
+
+  kafka-connect:
+    image: confluentinc/cp-kafka-connect:5.4.0
+    hostname: kafka-connect
+    container_name: kafka-connect
+    depends_on:
+      - broker
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: 'broker:29092'
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: 'quickstart'
+      CONNECT_CONFIG_STORAGE_TOPIC: 'quickstart-config'
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_OFFSET_STORAGE_TOPIC: 'quickstart-offsets'
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_STATUS_STORAGE_TOPIC: 'quickstart-status'
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_KEY_CONVERTER: 'org.apache.kafka.connect.storage.StringConverter'
+      CONNECT_VALUE_CONVERTER: 'org.apache.kafka.connect.json.JsonConverter'
+#     CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+#     CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      CONNECT_INTERNAL_KEY_CONVERTER: 'org.apache.kafka.connect.storage.StringConverter'
+      CONNECT_INTERNAL_VALUE_CONVERTER: 'org.apache.kafka.connect.json.JsonConverter'
+      CONNECT_REST_ADVERTISED_HOST_NAME: 'kafka-connect'
+      CONNECT_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      CONNECT_PLUGIN_PATH: '/usr/share/java'
+
+
+  cratedb:
+    image: crate/crate:nightly
+    hostname: cratedb
+    container_name: cratedb
+    ports:
+      - "5432:5432"
+      - "4200:4200"
+    environment:
+      CRATE_HEAP_SIZE: 1g


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This will add an integration test for the kafka-jdbc-connector in a docker and 


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
