### PR TITLE
Add query using scalars on rolling upgrade BWC test

### DIFF
--- a/tests/bwc/test_rolling_upgrade.py
+++ b/tests/bwc/test_rolling_upgrade.py
@@ -84,6 +84,16 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
                     GROUP BY type
                 ''')
                 c.fetchall()
+
+                # Ensure scalar symbols are working across versions
+                c.execute('''
+                    SELECT type, value + 1
+                    FROM doc.t1
+                    WHERE value > 1
+                    LIMIT 1
+                ''')
+                c.fetchone()
+
                 # Ensure that inserts, which will create a new partition, are working while upgrading
                 c.execute("INSERT INTO doc.parted (id, value) VALUES (?, ?)", [idx + 10, idx + 10])
                 # Add the shards of the new partition primaries


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Ensure scalar symbols are correctly streamed and resolved on a
mixed version cluster.
This ensures BWC of the new signature based function registry.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
