### PR TITLE
Fix formatting of rows

### DIFF
--- a/tests/bwc/test_rolling_upgrade.py
+++ b/tests/bwc/test_rolling_upgrade.py
@@ -78,7 +78,7 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
             with connect(new_node.http_url, error_trace=True) as conn:
                 c = conn.cursor()
                 wait_for_active_shards(c, expected_active_shards)
-                c.execute(f'''
+                c.execute('''
                     SELECT type, AVG(value)
                     FROM doc.t1
                     GROUP BY type
@@ -94,10 +94,10 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
         with connect(cluster.node().http_url, error_trace=True) as conn:
             c = conn.cursor()
             wait_for_active_shards(c, expected_active_shards)
-            c.execute(f'''
+            c.execute('''
                 REFRESH TABLE doc.parted
             ''')
-            c.execute(f'''
+            c.execute('''
                 SELECT count(*)
                 FROM doc.parted
             ''')


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Row values must be formatted to the given format before the sorting mode is applied (formatting must happen on the original result set).

This fixes test failures against CrateDB >= 4.2, it was succeeding on older versions because older CrateDB versions had some arithmetic type issues. The column type was always dictating the result type which by coincident matched the expected type format of the sqllogic tests.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
