### PR TITLE
Add aggregation stmt for rolling upgrade test

### DIFF
--- a/tests/bwc/test_rolling_upgrade.py
+++ b/tests/bwc/test_rolling_upgrade.py
@@ -84,6 +84,13 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
                     GROUP BY type
                 ''')
                 c.fetchall()
+                # Ensure aggregation with different intermediate input works, this was an regression for 4.1 <-> 4.2
+                c.execute('''
+                    SELECT type, count(distinct value)
+                    FROM doc.t1
+                    GROUP BY type
+                ''')
+                c.fetchall()
 
                 # Ensure scalar symbols are working across versions
                 c.execute('''


### PR DESCRIPTION
We had a regression on BWC for aggregations which have a different intermediate input data type than the initial argument type causing aggregation streamed from a 4.1 node to a 4.2 node to not being resolvable. 
This adds the related statement to the rolling upgrade test to ensure that it will correctly work on mixed version clusters.

Relates https://github.com/crate/crate/pull/10557.