### PR TITLE
Use docker image for go client tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,16 +105,22 @@ pipeline {
           }
         }
         stage('Go client tests') {
-          agent { label 'medium' }
+          agent {
+            dockerfile {
+              label 'docker'
+              filename 'tests/client_tests/go/Dockerfile'
+            }
+          }
           steps {
             checkout scm
             sh '''
-              rm -rf env
-              /usr/bin/python3.7 -m venv env
-              source env/bin/activate
+              export HOME=$(pwd)
+              export LANG=en_US.UTF-8
+              test -d env && rm -rf env
+              python3 -m venv env
+              . env/bin/activate
               python -m pip install -U cr8 crash
-              jabba install $JDK_11
-              JAVA_HOME=$(jabba which --home $JDK_11) tests/client_tests/go/run.sh
+              (cd tests/client_tests/go && ./run.sh)
             '''
           }
         }

--- a/tests/client_tests/go/Dockerfile
+++ b/tests/client_tests/go/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.15
+
+RUN \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get -y install python3-venv
+
+ENV HOME /root
+WORKDIR /root
+USER root
+
+CMD ["bash"]


### PR DESCRIPTION
Jenkins has not up-to-date go version installed and thus the client test fail currently.
Use a docker golang image now instead to avoid host/jenkins global installation dependencies.
