### PR TITLE
Ensure python header files are available in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:latest
 RUN \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install openjdk-11-jdk python3-venv
+  apt-get -y install openjdk-11-jdk python3-venv python3-dev
 
 ENV HOME /root
 WORKDIR /root

--- a/tests/client_tests/go/Dockerfile
+++ b/tests/client_tests/go/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.15
 RUN \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install python3-venv
+  apt-get -y install python3-venv python3-dev
 
 ENV HOME /root
 WORKDIR /root

--- a/tests/client_tests/node-postgres/Dockerfile
+++ b/tests/client_tests/node-postgres/Dockerfile
@@ -1,16 +1,12 @@
-FROM openjdk:13
+FROM node:15-buster
 
 RUN \
-  yum install deltarpm -y && \
-  yum update -y && \
-  yum install python3 -y && \
-  yum install -y gcc-c++ make && \
-  curl -sL https://rpm.nodesource.com/setup_13.x | bash - && \
-  yum install nodejs -y && \
-  useradd -ms /bin/bash crate
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get -y install python3-venv python3-dev
 
-ENV HOME /home/crate
-WORKDIR /home/crate
-USER crate
+ENV HOME /root
+WORKDIR /root
+USER ROOT
 
 CMD ["bash"]

--- a/tests/client_tests/stock_npgsql/Dockerfile
+++ b/tests/client_tests/stock_npgsql/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 RUN \
   apt-get update && \
   apt-get -y upgrade && \
-  apt-get -y install python3-venv
+  apt-get -y install python3-venv python3-dev
 
 ENV HOME /root
 WORKDIR /root


### PR DESCRIPTION
Some of the dependencies pulled in via pip require to be built and need the python header files