### PR TITLE
Add post workspace cleanup step to jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,4 +226,9 @@ pipeline {
       }
     }
   }
+  post {
+    cleanup {
+      deleteDir()  /* clean up our workspace */
+    }
+  }
 }


### PR DESCRIPTION
Sometimes old builds leave traces behind which could break new builds.
(E.g. if a client test switches to a docker build, but some caches
or env vars still exists at the workspace. Did happen for golang tests).

Cleaning up the workspace as a post step should avoid that.