### PR TITLE
Fix flaky bwc recovery tests by only upgrade 1 node at a time

### DIFF
--- a/tests/bwc/test_recovery.py
+++ b/tests/bwc/test_recovery.py
@@ -384,6 +384,10 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             inserts = [(i, str(random.randint)) for i in range(0, 100)]
             c.executemany('''insert into doc.test(id, data) values (?, ?)''', inserts)
 
+            # ensure all shards are active before upgrading a node. otherwise the cluster tries to allocate new
+            # replicas if the upgraded node contained the primary, which will fail due to node version allocation rules.
+            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+
             self._upgrade_to_mixed_cluster(cluster, path.to_version)
 
             if random.choice([True, False]):


### PR DESCRIPTION
If multiple nodes are upgraded at once while other nodes are still
on older versions, the cluster may not be able to (re-) allocate
all shards (replicas) resulting in a YELLOW cluster health.

Additionally for one test scenario, we must ensure that all replica shards are active before any node
is upgraded. Otherwise the cluster may try to allocate new replica shards if the upgraded node contains the primary shard. This would fail then due to node version based allocation rules (a replica cannot be allocated on a node which has a lower version than the primary).