### PR TITLE
node-postgres: Add test case for INSERTs with parameterized timestamp

### DIFF
--- a/tests/client_tests/node-postgres/README.rst
+++ b/tests/client_tests/node-postgres/README.rst
@@ -15,7 +15,7 @@ Run it like:
 When running CrateDB through Docker, try::
 
 	docker run -it --rm --publish 5432:5432 crate:4.3.3
-	node main.js localhost 5432
+	node --trace-warnings main.js localhost 5432
 
 
 .. _nodejs: https://nodejs.org/en/

--- a/tests/client_tests/node-postgres/backlog.rst
+++ b/tests/client_tests/node-postgres/backlog.rst
@@ -1,0 +1,25 @@
+################################################
+Backlog for CrateDB client tests (node-postgres)
+################################################
+
+
+Use a real testing framework
+============================
+
+We should use a real testing framework for improved structure, test case
+discovery and better reporting. It will probably also deliver a mechanism
+for measuring code coverage and other features.
+
+Currently, the tests are based on Chai_, which is essentially just an
+assertion library. Chai_ can be accompanied by Mocha_ to build a whole
+test suite framework, see `How to make tests using chai and mocha?`_.
+
+On the other hand, the `tests for node-postgres`_ are based on Lerna_.
+
+
+.. _Chai: https://www.chaijs.com/
+.. _Mocha: https://mochajs.org/
+.. _How to make tests using chai and mocha?: https://itnext.io/how-to-make-tests-using-chai-and-mocha-e9db7d8d48bc
+
+.. _tests for node-postgres: https://github.com/brianc/node-postgres/tree/master/packages/pg/test
+.. _Lerna: https://github.com/lerna/lerna

--- a/tests/client_tests/node-postgres/db.js
+++ b/tests/client_tests/node-postgres/db.js
@@ -30,20 +30,20 @@ async function setup_table() {
     let testTableName = `"doc"."tmp_table_${id}"`;
     await execute(
         `CREATE TABLE ${testTableName} (` +
-        '        log_time timestamp NOT NULL,' +
-        '        client_ip ip NOT NULL,' +
-        '        request string NOT NULL,' +
-        '        status_code short NOT NULL,' +
-        '        object_size long NOT NULL);'
+        '        log_time timestamp,' +
+        '        client_ip ip,' +
+        '        request string,' +
+        '        status_code short,' +
+        '        object_size long);'
     )
     return testTableName;
 }
 
 
 
-function execute(sql) {
+function execute(sql, parameters) {
     try {
-        return pgClientPool.query(sql);
+        return pgClientPool.query(sql, parameters);
     } catch (error) {
         console.error(`The horror: ${error}`);
         throw error;

--- a/tests/client_tests/node-postgres/package-lock.json
+++ b/tests/client_tests/node-postgres/package-lock.json
@@ -62,6 +62,14 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-datetime": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.7.0.tgz",
+      "integrity": "sha512-4kPT3R1tr0ujZ+xRTOzvGiZOzC30URFT+28/gd/vusOhumSH/o6TVI4yZMsQTwc+UUGpvIdx1wChQQVZkTbq/g==",
+      "requires": {
+        "chai": ">1.9.0"
+      }
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",

--- a/tests/client_tests/node-postgres/package.json
+++ b/tests/client_tests/node-postgres/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "app": "^0.1.0",
     "chai": "^4.2.0",
+    "chai-datetime": "^1.7.0",
     "pg": "^8.5.1",
     "uuid": "^3.4.0"
   }

--- a/tests/client_tests/node-postgres/test_parameterized_timestamp.js
+++ b/tests/client_tests/node-postgres/test_parameterized_timestamp.js
@@ -1,0 +1,45 @@
+const cratedb = require('./db');
+
+const chai = require('chai');
+chai.use(require('chai-datetime'));
+
+const expect = chai.expect;
+
+
+async function run() {
+    /*
+    Investigate parameterized INSERT statements with TIMESTAMP columns
+    (server-side binding) using CrateDB with PostgreSQL protocol.
+
+    https://gist.github.com/amotl/b25297e7dc5a7f744aebb04ce4960833
+    */
+
+    // Set up a ephemeral database table.
+    let testTableName = await cratedb.setup_table();
+
+    // Invoke the `INSERT` statement.
+    await cratedb.execute(
+        `INSERT INTO ${testTableName} ("log_time") VALUES ($1);`,
+        ['2021-01-13T14:37:17.25988Z']
+    );
+
+    // Make sure the `INSERT` is synchronized.
+    await cratedb.execute(`REFRESH TABLE ${testTableName};`);
+
+    // Check the outcome.
+    let response = await cratedb.execute(`SELECT * FROM ${testTableName};`);
+    let data = response.rows;
+    if (!data) {
+        throw new Error('expected data, got nothing back');
+    }
+    expect(data).to.have.lengthOf(1);
+    expect(data[0]).to.have.property('log_time');
+    expect(data[0]['log_time']).to.be.a('Date');
+    expect(data[0]['log_time']).to.equalDate(new Date('2021-01-13T14:37:17.25988Z'));
+
+}
+
+
+module.exports = {
+    run,
+};


### PR DESCRIPTION
Hi there,

this adds a test case which outlines a regression discovered with CrateDB 4.3.3, see [1]. With one of the next iterations, we should introduce a real test framework instead of rolling our own, see [2].

With kind regards,
Andreas.

[1] https://gist.github.com/amotl/b25297e7dc5a7f744aebb04ce4960833
[2] https://github.com/crate/crate-qa/blob/91f306/tests/client_tests/node-postgres/backlog.rst

P.S.: This will probably fail until CrateDB 4.3.4 can be used.
