### PR TITLE
Fix NoneType error in retention lease assertion

### DIFF
--- a/tests/bwc/test_recovery.py
+++ b/tests/bwc/test_recovery.py
@@ -689,5 +689,5 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             retaining_seq_no = r[3]
             self.assertEqual(global_checkpoint, max_seq_no)
             self.assertEqual(local_checkpoint, max_seq_no)
-            for r_seq in retaining_seq_no:
+            for r_seq in retaining_seq_no or []:
                 self.assertEqual(r_seq, global_checkpoint + 1)


### PR DESCRIPTION
`retention_leases['leases']['retaining_seq_no']` can be null if there
aren't any retention leases yet.