### PR TITLE
Add a timeout to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,9 @@ pipeline {
   environment {
     JDK_11 = 'openjdk@1.11.0'
   }
+  options {
+    timeout(time: 4, unit: 'HOURS') 
+  }
   stages {
     stage('Parallel') {
       parallel {


### PR DESCRIPTION
We've had the tests get stuck for days before noticing.

This adds a timeout that's large enough to ensure the tests can finish
if things are working and ensures we notice if things aren't working.