### PR TITLE
npgsql: Add "build-essential" to list of dependency packages

### DIFF
--- a/tests/client_tests/stock_npgsql/Dockerfile
+++ b/tests/client_tests/stock_npgsql/Dockerfile
@@ -2,8 +2,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 RUN \
   apt-get update && \
-  apt-get -y upgrade && \
-  apt-get -y install python3-venv python3-dev
+  apt-get -y install python3-venv python3-dev build-essential
 
 ENV HOME /root
 WORKDIR /root


### PR DESCRIPTION
Hi there,

jobs like [1] occasionally fail when running the _npgsql client tests_ like
```
unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

I have been able to reproduce the error in isolation when just invoking Docker and following the recipe.
```sh
docker run -it --rm mcr.microsoft.com/dotnet/core/sdk:3.1 bash
apt-get update && apt-get -y install python3-venv python3-dev

root@ab9bf88e6209:/# x86_64-linux-gnu-gcc
bash: x86_64-linux-gnu-gcc: command not found
```

So, let's just add the `build-essential` package in order to satisfy the build. Why this apparently was able to succeed from time to time is beyond my imagination.

With kind regards,
Andreas.

[1] https://jenkins.crate.io/blue/organizations/jenkins/CrateDB%2Fqa%2Fcrate_qa_on_pr/detail/crate_qa_on_pr/564/pipeline/31