### PR TITLE
Fix TypeError in _assert_ensure_peer_recovery_retention_leases_renewed_and_synced

### DIFF
--- a/tests/bwc/test_recovery.py
+++ b/tests/bwc/test_recovery.py
@@ -689,5 +689,6 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             retaining_seq_no = r[3]
             self.assertEqual(global_checkpoint, max_seq_no)
             self.assertEqual(local_checkpoint, max_seq_no)
+            self.assertIsNotNone(retaining_seq_no)
             for r_seq in retaining_seq_no:
                 self.assertEqual(r_seq, global_checkpoint + 1)


### PR DESCRIPTION
`retention_leases['leases']` can be null if the leases aren't synced
yet.
This caused a `TypeError` which wasn't catched by the `assert_busy`
routine. So this adds a `assertIsNotNone` check to ensure the
`assert_busy` routine re-tries until the sync happened.

This replaces https://github.com/crate/crate-qa/pull/183 