### PR TITLE
Fix hotfix downgrade test and mark it as skipped

### DIFF
--- a/tests/bwc/test_hotfix_downgrades.py
+++ b/tests/bwc/test_hotfix_downgrades.py
@@ -6,6 +6,11 @@ from crate.client import connect
 
 class HotfixDowngradeTest(NodeProvider, unittest.TestCase):
 
+    @unittest.skip("""
+    This is expected to fail until CrateDB v4.4.4 is out as all
+    versions < 4.4.3 won't fully support hotfix version downgrades.
+    See https://github.com/crate/crate/pull/11103.
+    """)
     def test_latest_testing_can_be_downgraded_within_hotfix_versions(self):
         cluster = self._new_cluster('latest-testing', 2)
         cluster.start()

--- a/tests/bwc/test_hotfix_downgrades.py
+++ b/tests/bwc/test_hotfix_downgrades.py
@@ -15,7 +15,7 @@ class HotfixDowngradeTest(NodeProvider, unittest.TestCase):
             c.execute('CREATE TABLE tbl (x int)')
             c.execute('INSERT INTO tbl (x) values (?)', (10,))
         major, feature, hotfix = node.version
-        for i in range(hotfix, 0, -1):
+        for i in range(hotfix, -1, -1):
             new_version = (major, feature, i)
             with self.subTest(version=new_version):
                 node = self.upgrade_node(node, '.'.join(map(str, new_version)))


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

-  Fix hotfix downgrade test to include downgrade paths to X.X.0 versions.
    Due to this bug, the test did not run e.g. on the downgrade path 4.4.1 -> 4.4.0

-  Skip hotfix downgrade path at is currently expected to fail
All CrateDB versions < 4.4.3 won't support allocation of shards
on nodes with lower hotfix version.
See crate/crate#11103.
We must re-enable this, once we have versions published including
this fix.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
