### PR TITLE
Disable bwc.test_recovery test suite until flakyness is solved

### DIFF
--- a/tests/bwc/test_recovery.py
+++ b/tests/bwc/test_recovery.py
@@ -17,6 +17,7 @@ UPGRADE_PATHS = [
 UPGRADE_PATHS_FROM_43 = [UpgradePath('4.3.x', '4.4.x')]
 
 
+@unittest.skip('Recovery tests are currently flaky, skip them until fixed')
 class RecoveryTest(NodeProvider, unittest.TestCase):
     """
     In depth testing of the recovery mechanism during a rolling restart.


### PR DESCRIPTION
The test inside the RecoveryTest suite are failing occasionally.
Until this is fixed, they are disabled in order to let all other
tests run. Otherwise possible other issues won't pop up anymore.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
