### PR TITLE
Change kafka version to latest for kafka jdbc integration test

### DIFF
--- a/tests/kafka-connect-jdbc/docker-compose.yml
+++ b/tests/kafka-connect-jdbc/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
       CONNECT_REST_ADVERTISED_HOST_NAME: 'kafka-connect'
       CONNECT_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      CONNECT_PLUGIN_PATH: '/usr/share/java,/etc/kafka-connect/plugins'
+      CONNECT_PLUGIN_PATH: /usr/share/java/,/etc/kafka-connect/jars
 
 
   cratedb:

--- a/tests/kafka-connect-jdbc/docker-compose.yml
+++ b/tests/kafka-connect-jdbc/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.1'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.4.0
+    image: confluentinc/cp-zookeeper:6.2.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:5.4.0
+    image: confluentinc/cp-kafka:6.2.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.4.0
+    image: confluentinc/cp-schema-registry:6.2.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   kafka-connect:
-    image: confluentinc/cp-kafka-connect:5.4.0
+    image: confluentinc/cp-kafka-connect:6.2.0
     hostname: kafka-connect
     container_name: kafka-connect
     depends_on:

--- a/tests/kafka-connect-jdbc/docker-compose.yml
+++ b/tests/kafka-connect-jdbc/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
       CONNECT_REST_ADVERTISED_HOST_NAME: 'kafka-connect'
       CONNECT_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      CONNECT_PLUGIN_PATH: '/usr/share/java'
+      CONNECT_PLUGIN_PATH: '/usr/share/java,/etc/kafka-connect/jars'
 
 
   cratedb:

--- a/tests/kafka-connect-jdbc/docker-compose.yml
+++ b/tests/kafka-connect-jdbc/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
       CONNECT_REST_ADVERTISED_HOST_NAME: 'kafka-connect'
       CONNECT_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      CONNECT_PLUGIN_PATH: '/usr/share/java,/etc/kafka-connect/jars'
+      CONNECT_PLUGIN_PATH: '/usr/share/java,/etc/kafka-connect/plugins'
 
 
   cratedb:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This updates all kafka related libraries for the jdbc integration to the latest version.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
