### PR TITLE
Add test for parallel drop and restore for snapshots

### DIFF
--- a/src/crate/qa/tests.py
+++ b/src/crate/qa/tests.py
@@ -300,3 +300,19 @@ class NodeProvider:
 
     def _has_error(self) -> bool:
         return any(error for (_, error) in self._outcome.errors)  # type: ignore
+
+
+def assert_busy(assertion, timeout=120, f=2.0):
+    waited = 0
+    sleep_interval_sec = 0.1
+    assertion_error = None
+    while waited < timeout:
+        try:
+            assertion()
+            return
+        except AssertionError as e:
+            assertion_error = e
+            time.sleep(sleep_interval_sec)
+            waited += sleep_interval_sec
+            sleep_interval_sec *= f
+    raise assertion_error

--- a/tests/bwc/test_recovery.py
+++ b/tests/bwc/test_recovery.py
@@ -1,4 +1,3 @@
-import time
 import unittest
 
 from cr8.run_crate import get_crate, _extract_version
@@ -6,7 +5,7 @@ from crate.client import connect
 import random
 from random import sample
 
-from crate.qa.tests import NodeProvider, insert_data, UpgradePath
+from crate.qa.tests import NodeProvider, insert_data, UpgradePath, assert_busy
 
 UPGRADE_PATHS = [
     UpgradePath('4.2.x', '4.3.x'),
@@ -26,21 +25,6 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
     """
 
     NUMBER_OF_NODES = 3
-
-    def assert_busy(self, assertion, timeout=120, f=2.0):
-        waited = 0
-        duration = 0.1
-        assertion_error = None
-        while waited < timeout:
-            try:
-                assertion()
-                return
-            except AssertionError as e:
-                assertion_error = e
-            time.sleep(duration)
-            waited += duration
-            duration *= f
-        raise assertion_error
 
     def _assert_num_docs_by_node_id(self, conn, schema, table_name, node_id, expected_count):
         c = conn.cursor()
@@ -134,7 +118,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             # insert data into the initial homogeneous cluster
             insert_data(conn, 'doc', 'test', 10)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
             # make sure that we can index while the replicas are recovering
             c.execute('''alter table doc.test set ("routing.allocation.enable"='primaries')''')
 
@@ -152,10 +136,10 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             node_ids = c.fetchall()
             self.assertEqual(len(node_ids), self.NUMBER_OF_NODES)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             for node_id in node_ids:
-                self.assert_busy(lambda: self._assert_num_docs_by_node_id(conn, 'doc', 'test', node_id[0], 60))
+                assert_busy(lambda: self._assert_num_docs_by_node_id(conn, 'doc', 'test', node_id[0], 60))
 
             c.execute('''alter table doc.test set ("routing.allocation.enable"='primaries')''')
             # upgrade the full cluster
@@ -173,7 +157,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             self.assertEqual(len(node_ids), self.NUMBER_OF_NODES)
 
             for node_id in node_ids:
-                self.assert_busy(lambda: self._assert_num_docs_by_node_id(conn, 'doc', 'test', node_id[0], 105))
+                assert_busy(lambda: self._assert_num_docs_by_node_id(conn, 'doc', 'test', node_id[0], 105))
 
     def test_relocation_with_concurrent_indexing(self):
         self._run_upgrade_paths(self._test_relocation_with_concurrent_indexing, UPGRADE_PATHS)
@@ -191,7 +175,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
 
             insert_data(conn, 'doc', 'test', 10)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
             # make sure that no shards are allocated, so we can make sure the primary stays
             # on the old node (when one node stops, we lose the master too, so a replica
             # will not be promoted)
@@ -211,15 +195,15 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
                         "routing.allocation.include._id"=?
                         )''', (old_node_id, ))
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             c.execute('''alter table doc.test set ("routing.allocation.include._id"=?)''', (new_node_id, ))
             insert_data(conn, 'doc', 'test', 50)
 
             # ensure the relocation from old node to new node has occurred; otherwise the table is green
             # even though shards haven't moved to the new node yet (allocation was throttled).
-            self.assert_busy(lambda: self._assert_shard_state(conn, 'doc', 'test', new_node_id, 'STARTED'))
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_shard_state(conn, 'doc', 'test', new_node_id, 'STARTED'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             c.execute('refresh table doc.test')
             self._assert_num_docs_by_node_id(conn, 'doc', 'test', new_node_id, 60)
@@ -232,7 +216,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
 
             insert_data(conn, 'doc', 'test', 45)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
             c.execute('refresh table doc.test')
             c.execute('select id from sys.nodes')
             node_ids = c.fetchall()
@@ -277,7 +261,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
 
             self._upgrade_to_mixed_cluster(cluster, path.to_version)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             # upgrade fully to the new version
             self._upgrade_cluster(cluster, path.to_version, self.NUMBER_OF_NODES)
@@ -285,7 +269,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             if random.choice([True, False]):
                 c.execute("refresh table doc.test")
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
     def test_recovery_closed_index(self):
         """
@@ -306,7 +290,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
                         "unassigned.node_left.delayed_timeout" = '100ms', "allocation.max_retries" = '0')
                       ''')
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             c.execute('alter table doc.test close')
 
@@ -350,7 +334,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
                       create table doc.mixed_cluster(x int) clustered into 1 shards with( number_of_replicas = 0)
                       ''')
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'mixed_cluster'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'mixed_cluster'))
             c.execute('alter table doc.mixed_cluster close')
 
             self._assert_is_closed(conn, 'doc', 'mixed_cluster')
@@ -365,7 +349,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
                       create table doc.upgraded_cluster(x int) clustered into 1 shards with( number_of_replicas = 0)
                       ''')
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'upgraded_cluster'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'upgraded_cluster'))
             c.execute('alter table doc.upgraded_cluster close')
 
             self._assert_is_closed(conn, 'doc', 'upgraded_cluster')
@@ -393,12 +377,12 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
 
             # ensure all shards are active before upgrading a node. otherwise the cluster tries to allocate new
             # replicas if the upgraded node contained the primary, which will fail due to node version allocation rules.
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             self._upgrade_to_mixed_cluster(cluster, path.to_version)
 
             if random.choice([True, False]):
-                self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+                assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             # update the data in a mixed cluster
             updates = [(i, str(random.randint)) for i in range(0, 100)]
@@ -411,7 +395,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
                 self.assertEqual(result['rowcount'], 1)
 
             if random.choice([True, False]):
-                self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+                assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             # upgrade fully to the new version
             self._upgrade_cluster(cluster, path.to_version, self.NUMBER_OF_NODES)
@@ -446,7 +430,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
                         "soft_deletes.enabled" = true)
                         ''')
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             insert_data(conn, 'doc', 'test', random.randint(100, 200))
             c.execute('refresh table doc.test')
@@ -458,7 +442,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
 
             self._upgrade_to_mixed_cluster(cluster, path.to_version)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             num_docs = random.randint(0, 3)
             if num_docs > 0:
@@ -468,7 +452,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             # upgrade fully to the new version
             self._upgrade_cluster(cluster, path.to_version, self.NUMBER_OF_NODES)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             num_docs = random.randint(0, 3)
             if num_docs > 0:
@@ -496,7 +480,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
                         "soft_deletes.enabled" = true)
                      ''', (number_of_replicas, ))
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             insert_data(conn, 'doc', 'test', random.randint(100, 200))
             c.execute('refresh table doc.test')
@@ -508,7 +492,7 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             # update the cluster to the new version
             self._upgrade_cluster(cluster, path.to_version, self.NUMBER_OF_NODES)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
             c.execute('refresh table doc.test')
             self._assert_translog_is_empty(conn, 'doc', 'test')
 
@@ -550,30 +534,30 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
 
             c.execute('''create table doc.test(x int) clustered into 1 shards with( "number_of_replicas" = ?)''',
                       (f"0-{number_of_replicas}",))
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             # exclude one node from allocation, but this won't have any effect as all nodes are on the old version
             c.execute('alter table doc.test set ("routing.allocation.exclude._id" = ?)', (random.choice(node_ids)[0],))
 
             # check that the replicas expanding automatically to all nodes, even that one is excluded
-            self.assert_busy(lambda: self._assert_number_of_replicas(conn, 'doc', 'test', number_of_replicas))
+            assert_busy(lambda: self._assert_number_of_replicas(conn, 'doc', 'test', number_of_replicas))
 
             self._upgrade_to_mixed_cluster(cluster, path.to_version)
 
             # health is yellow because the replicas are expanded, but one could not be allocated as the node
             # is excluded by allocation filtering
-            self.assert_busy(lambda: self._assert_is_yellow(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_yellow(conn, 'doc', 'test'))
 
             # check that the replicas still expanding automatically to all nodes, even that one is excluded
-            self.assert_busy(lambda: self._assert_number_of_replicas(conn, 'doc', 'test', number_of_replicas))
+            assert_busy(lambda: self._assert_number_of_replicas(conn, 'doc', 'test', number_of_replicas))
 
             # upgrade fully to the new version
             self._upgrade_cluster(cluster, path.to_version, number_of_nodes)
 
             # now that all nodes are on the same version including the path to expand replicas based on the
             # allocation filtering, replicas are expanded only to 1 and the health is green
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
-            self.assert_busy(lambda: self._assert_number_of_replicas(conn, 'doc', 'test', number_of_replicas_with_excluded_node))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_number_of_replicas(conn, 'doc', 'test', number_of_replicas_with_excluded_node))
 
     def _assert_number_of_replicas(self, conn, schema, table_name, count):
         c = conn.cursor()
@@ -611,18 +595,18 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             if random.choice([True, False]):
                 c.execute('refresh table doc.test')
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             self._upgrade_to_mixed_cluster(cluster, path.to_version)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
-            self.assert_busy(lambda: self._assert_ensure_peer_recovery_retention_leases_renewed_and_synced(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_ensure_peer_recovery_retention_leases_renewed_and_synced(conn, 'doc', 'test'))
 
             # upgrade fully to the new version
             self._upgrade_cluster(cluster, path.to_version, number_of_nodes)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
-            self.assert_busy(lambda: self._assert_ensure_peer_recovery_retention_leases_renewed_and_synced(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_ensure_peer_recovery_retention_leases_renewed_and_synced(conn, 'doc', 'test'))
 
     def test_retention_leases_established_when_relocating_primary(self):
         self._run_upgrade_paths(self._test_retention_leases_established_when_relocating_primary, UPGRADE_PATHS_FROM_43)
@@ -654,10 +638,10 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             if random.choice([True, False]):
                 c.execute('refresh table doc.test')
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             self._upgrade_to_mixed_cluster(cluster, path.to_version)
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
 
             #  trigger a primary relocation by excluding the primary from this index
             c.execute('''select node['id'] from sys.shards where primary=true and table_name='test' ''')
@@ -665,14 +649,14 @@ class RecoveryTest(NodeProvider, unittest.TestCase):
             self.assertTrue(primary_id)
             c.execute('alter table doc.test set ("routing.allocation.exclude._id" = ?)', primary_id)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
-            self.assert_busy(lambda: self._assert_ensure_peer_recovery_retention_leases_renewed_and_synced(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_ensure_peer_recovery_retention_leases_renewed_and_synced(conn, 'doc', 'test'))
 
             # upgrade fully to the new version
             self._upgrade_cluster(cluster, path.to_version, number_of_nodes)
 
-            self.assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
-            self.assert_busy(lambda: self._assert_ensure_peer_recovery_retention_leases_renewed_and_synced(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_is_green(conn, 'doc', 'test'))
+            assert_busy(lambda: self._assert_ensure_peer_recovery_retention_leases_renewed_and_synced(conn, 'doc', 'test'))
 
     def _assert_ensure_peer_recovery_retention_leases_renewed_and_synced(self, conn, schema_name, table_name):
         c = conn.cursor()

--- a/tests/snapshot/test_snapshot.py
+++ b/tests/snapshot/test_snapshot.py
@@ -1,0 +1,84 @@
+import random
+import shutil
+import threading
+import unittest
+
+from cr8.run_crate import wait_until
+from crate.client import connect
+from crate.client.exceptions import ProgrammingError
+from crate.qa.minio_svr import MinioServer, _is_up
+from crate.qa.tests import NodeProvider, insert_data, wait_for_active_shards, gen_id, assert_busy
+
+
+class SnapshotOperationTest(NodeProvider, unittest.TestCase):
+
+    PATH_DATA = 'data_test_snapshot_ops'
+
+    def tearDown(self):
+        shutil.rmtree(self.PATH_DATA, ignore_errors=True)
+
+    def _assert_num_docs(self, conn, expected_count):
+        c = conn.cursor()
+        c.execute('SELECT COUNT(*) FROM doc.test')
+        rowcount = c.fetchone()[0]
+        self.assertEqual(rowcount, expected_count)
+
+    def test_snapshot_restore_and_drop_in_parallel(self):
+        """Test to run the drop and restore operation on two different
+           snapshots in parallel.
+
+        The purpose of this test is to validate that the snapshot mechanism
+        of CrateDB can handle the two operations in parallel. Here, Minio is
+        used as s3 backend for the repository, but this should work on any
+        other backend as well.
+        """
+        with MinioServer() as minio:
+            t = threading.Thread(target=minio.run)
+            t.daemon = True
+            t.start()
+            wait_until(lambda: _is_up('127.0.0.1', 9000))
+
+            num_nodes = random.randint(3, 5)
+            number_of_shards = random.randint(1, 3)
+            number_of_replicas = random.randint(0, 2)
+            num_docs = random.randint(1, 100)
+
+            cluster_settings = {
+                'cluster.name': gen_id(),
+                'path.data': self.PATH_DATA
+            }
+            shutil.rmtree(self.PATH_DATA, ignore_errors=True)
+            cluster = self._new_cluster('latest-nightly', num_nodes, settings=cluster_settings)
+            cluster.start()
+
+            with connect(cluster.node().http_url, error_trace=True) as conn:
+                c = conn.cursor()
+                wait_for_active_shards(c)
+                c.execute('''
+                            create table doc.test(x int) clustered into ? shards with( number_of_replicas =?)
+                         ''', (number_of_shards, number_of_replicas,))
+
+                insert_data(conn, 'doc', 'test', num_docs)
+
+                c.execute('''
+                            CREATE REPOSITORY repo TYPE S3
+                            WITH (access_key = 'minio',
+                            secret_key = 'miniostorage',
+                            bucket='backups',
+                            endpoint = '127.0.0.1:9000',
+                            protocol = 'http')
+                        ''')
+
+                c.execute('CREATE SNAPSHOT repo.snapshot1 TABLE doc.test WITH (wait_for_completion = true)')
+                c.execute('CREATE SNAPSHOT repo.snapshot2 TABLE doc.test WITH (wait_for_completion = true)')
+                c.execute('DROP TABLE doc.test')
+                # Drop snapshot2 while the restore of snapshot1 is still running
+                c.execute('RESTORE SNAPSHOT repo.snapshot1 ALL WITH (wait_for_completion = false)')
+                try:
+                    c.execute('DROP SNAPSHOT repo.snapshot2')
+                except ProgrammingError:
+                    self.fail("Restore and Drop Snapshot operation should work in parallel")
+
+                assert_busy(lambda: self._assert_num_docs(conn, num_docs))
+
+            cluster.stop()


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Relates to https://github.com/crate/crate/pull/11820

Inspired by https://github.com/elastic/elasticsearch/commit/1064009e9d967bd9e81e10f4eb8dd33808ec1762#diff-b14376ec9051ae5d30b80f77846aefdc262eb791876f50c55193908e4a818f05R524

See individual commits.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
