### PR TITLE
Update Jenkinsfile/tests for infrastructure changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,7 +238,7 @@ pipeline {
         }
         stage('kafka-connect jdbc tests') {
           agent {
-            label 'docker'
+            label 'docker && medium'
           }
           steps {
             checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,8 @@
 // https://www.jenkins.io/doc/book/pipeline/syntax/
 pipeline {
   agent any
-  environment {
-    JDK_11 = 'openjdk@1.11.0'
-  }
   options {
-    timeout(time: 4, unit: 'HOURS') 
+    timeout(time: 4, unit: 'HOURS')
   }
   stages {
     stage('Parallel') {
@@ -116,7 +113,7 @@ pipeline {
           }
         }
         stage('Haskell client tests') {
-          agent { label 'medium' }
+          agent { label 'docker' }
           steps {
             checkout scm
             sh '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,9 +34,6 @@ pipeline {
               source env/bin/activate
               python -m pip install -U -e .
 
-              jabba install $JDK_11
-              export JAVA_HOME=$(jabba which --home $JDK_11)
-
               (cd tests && python -m unittest discover -vvvf -s bwc)
             '''
           }
@@ -50,9 +47,6 @@ pipeline {
               /usr/bin/python3.7 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
-
-              jabba install $JDK_11
-              export JAVA_HOME=$(jabba which --home $JDK_11)
 
               (cd tests && python -m unittest discover -vvvf -s restart)
             '''
@@ -68,9 +62,6 @@ pipeline {
               source env/bin/activate
               python -m pip install -U -e .
 
-              jabba install $JDK_11
-              export JAVA_HOME=$(jabba which --home $JDK_11)
-
               (cd tests && python -m unittest discover -vvvf -s startup)
             '''
           }
@@ -84,9 +75,6 @@ pipeline {
               /usr/bin/python3.7 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
-
-              jabba install $JDK_11
-              export JAVA_HOME=$(jabba which --home $JDK_11)
 
               git submodule update --init
               (cd tests && python -m unittest discover -vvvf -s sqllogic)
@@ -102,9 +90,6 @@ pipeline {
               /usr/bin/python3.7 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
-
-              jabba install $JDK_11
-              export JAVA_HOME=$(jabba which --home $JDK_11)
 
               (cd tests && python -m unittest discover -vvvf -s client_tests)
             '''
@@ -139,11 +124,10 @@ pipeline {
               /usr/bin/python3.7 -m venv env
               source env/bin/activate
               python -m pip install -U cr8
-              jabba install $JDK_11
               mkdir -p ~/.local/bin
               export PATH=$HOME/.local/bin:$PATH
               curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-              JAVA_HOME=$(jabba which --home $JDK_11) tests/client_tests/haskell/run.sh
+              ./tests/client_tests/haskell/run.sh
             '''
           }
         }
@@ -152,8 +136,6 @@ pipeline {
           steps {
             checkout scm
             sh '''
-              jabba install $JDK_11
-              export JAVA_HOME=$(jabba which --home $JDK_11)
               (cd tests/client_tests/stock_jdbc && ./gradlew test)
             '''
           }
@@ -264,8 +246,6 @@ pipeline {
           steps {
             checkout scm
             sh '''
-              jabba install $JDK_11
-              export JAVA_HOME=$(jabba which --home $JDK_11)
               (cd tests/kafka-connect-jdbc/ && ./run.sh)
             '''
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
           steps {
             checkout scm
             sh 'rm -rf env'
-            sh '/usr/bin/python3.7 -m venv env'
+            sh '/usr/bin/python3 -m venv env'
             sh 'env/bin/python -m pip install -U mypy flake8'
             sh 'find tests -name "*.py" | xargs env/bin/mypy --ignore-missing-imports'
             sh 'find src -name "*.py" | xargs env/bin/mypy --ignore-missing-imports'
@@ -30,7 +30,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3.7 -m venv env
+              /usr/bin/python3 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -44,7 +44,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3.7 -m venv env
+              /usr/bin/python3 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -58,7 +58,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3.7 -m venv env
+              /usr/bin/python3 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -72,7 +72,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3.7 -m venv env
+              /usr/bin/python3 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -87,7 +87,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3.7 -m venv env
+              /usr/bin/python3 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -121,7 +121,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3.7 -m venv env
+              /usr/bin/python3 -m venv env
               source env/bin/activate
               python -m pip install -U cr8
               mkdir -p ~/.local/bin

--- a/tests/client_tests/haskell/stack.yaml
+++ b/tests/client_tests/haskell/stack.yaml
@@ -1,9 +1,11 @@
 ---
-resolver: lts-13.28
+resolver: lts-18.24
+
+docker:
+  enable: true
 
 packages:
   - .
 
-extra-deps: [
-  "HDBC-postgresql-2.3.2.5"
-]
+extra-deps:
+  - HDBC-postgresql-2.5.0.0@sha256:10ceb4f456bbd4768a3f0ab425d9b4d40cb0e17992083b881b37fe5d91b58aba

--- a/tests/client_tests/haskell/stack.yaml.lock
+++ b/tests/client_tests/haskell/stack.yaml.lock
@@ -5,15 +5,15 @@
 
 packages:
 - completed:
-    hackage: HDBC-postgresql-2.3.2.5@sha256:5d46e19ddd92349546117d5558b7d1a9d0f7fa363a394e21bb41cc39acc6d0d7,3213
+    hackage: HDBC-postgresql-2.5.0.0@sha256:10ceb4f456bbd4768a3f0ab425d9b4d40cb0e17992083b881b37fe5d91b58aba,3050
     pantry-tree:
-      size: 1730
-      sha256: c75821e0c0d10b785a19999d635f2c10a5891b33c48ffcc3e0963e681a861618
+      size: 1611
+      sha256: 9db472e5f433c07d097b6cdc6af354d0a40c0fd3c7205510973380ced739c764
   original:
-    hackage: HDBC-postgresql-2.3.2.5
+    hackage: HDBC-postgresql-2.5.0.0@sha256:10ceb4f456bbd4768a3f0ab425d9b4d40cb0e17992083b881b37fe5d91b58aba
 snapshots:
 - completed:
-    size: 500539
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/28.yaml
-    sha256: cdde1bfb38fdee21c6acb73d506e78f7e12e0a73892adbbbe56374ebef4d3adf
-  original: lts-13.28
+    size: 587821
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/24.yaml
+    sha256: 06d844ba51e49907bd29cb58b4a5f86ee7587a4cd7e6cf395eeec16cba619ce8
+  original: lts-18.24

--- a/tests/client_tests/odbc/test_pyodbc.py
+++ b/tests/client_tests/odbc/test_pyodbc.py
@@ -22,7 +22,7 @@ def open_db_connection(connection_string):
 
 class PyODBCTestCase(NodeProvider, unittest.TestCase):
 
-    DRIVER_NAME = os.environ.get('ODBC_DRIVER_NAME', 'PostgreSQL')
+    DRIVER_NAME = os.environ.get('ODBC_DRIVER_NAME', 'PostgreSQL Unicode')
 
     def connection_str(self, node):
         database = 'doc'

--- a/tests/kafka-connect-jdbc/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/kafka-connect-jdbc/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

JDK11 is available on the slaves and some of the jobs even don't need a
JDK because they're using the bundled JDK in CrateDB


I think BWC test failure is a real issue - not related to the infrastructure changes. I'd like to merge the rest so that everything else works again.