### PR TITLE
Use custom docker image for haskell tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,17 +113,22 @@ pipeline {
           }
         }
         stage('Haskell client tests') {
-          agent { label 'docker' }
+          agent {
+            dockerfile {
+              label 'docker'
+              filename 'tests/client_tests/haskell/Dockerfile'
+            }
+          }
           steps {
             checkout scm
             sh '''
-              rm -rf env
-              /usr/bin/python3 -m venv env
-              source env/bin/activate
+              export HOME=$(pwd)
+              export LANG=en_US.UTF-8
+
+              test -d env && rm -rf env
+              python3 -m venv env
+              . env/bin/activate
               python -m pip install -U cr8
-              mkdir -p ~/.local/bin
-              export PATH=$HOME/.local/bin:$PATH
-              curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
               ./tests/client_tests/haskell/run.sh
             '''
           }

--- a/tests/client_tests/haskell/Dockerfile
+++ b/tests/client_tests/haskell/Dockerfile
@@ -1,0 +1,15 @@
+FROM haskell:8.10
+
+RUN \
+  apt-get update && \
+  apt-get -y install \
+    libpq-dev \
+    python3-venv \
+    python3-dev \
+    build-essential
+
+ENV HOME /root
+WORKDIR /root
+USER root
+
+CMD ["/bin/bash"]

--- a/tests/client_tests/haskell/stack.yaml
+++ b/tests/client_tests/haskell/stack.yaml
@@ -1,11 +1,8 @@
 ---
 resolver: lts-18.24
 
-docker:
-  enable: true
-
 packages:
   - .
 
 extra-deps:
-  - HDBC-postgresql-2.5.0.0@sha256:10ceb4f456bbd4768a3f0ab425d9b4d40cb0e17992083b881b37fe5d91b58aba
+  - HDBC-postgresql-2.5.0.1@sha256:37bb911cd996d12c91fa711002877f32f91bcc488de76d85a05865c3af9dc580,3032

--- a/tests/client_tests/haskell/stack.yaml.lock
+++ b/tests/client_tests/haskell/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: HDBC-postgresql-2.5.0.0@sha256:10ceb4f456bbd4768a3f0ab425d9b4d40cb0e17992083b881b37fe5d91b58aba,3050
+    hackage: HDBC-postgresql-2.5.0.1@sha256:37bb911cd996d12c91fa711002877f32f91bcc488de76d85a05865c3af9dc580,3032
     pantry-tree:
       size: 1611
-      sha256: 9db472e5f433c07d097b6cdc6af354d0a40c0fd3c7205510973380ced739c764
+      sha256: bb1e349a28844e59ed36e1a3963cd6946e57f5e39244a6d36397d6291d68a138
   original:
-    hackage: HDBC-postgresql-2.5.0.0@sha256:10ceb4f456bbd4768a3f0ab425d9b4d40cb0e17992083b881b37fe5d91b58aba
+    hackage: HDBC-postgresql-2.5.0.1@sha256:37bb911cd996d12c91fa711002877f32f91bcc488de76d85a05865c3af9dc580,3032
 snapshots:
 - completed:
     size: 587821


### PR DESCRIPTION
The default image seems to miss `pg_conf` which is required to build the
postgresql clients used in the tests


Force pushing too often seems to have broken the status reporting - test result is here: https://jenkins.crate.io/blue/organizations/jenkins/CrateDB%2Fqa%2Fcrate_qa_on_pr/detail/crate_qa_on_pr/34/pipeline/36 