### PR TITLE
reflect change of the timestamp alias to timestamp without time zone

### DIFF
--- a/tests/client_tests/odbc/test_pyodbc.py
+++ b/tests/client_tests/odbc/test_pyodbc.py
@@ -99,4 +99,4 @@ class PyODBCTestCase(NodeProvider, unittest.TestCase):
             cursor.execute("REFRESH TABLE t1")
             cursor.execute("SELECT t FROM t1 WHERE id = ?", 4)
             row = cursor.fetchone()
-            self.assertEqual('1999-01-08 02:05:06', row.t.strftime("%Y-%m-%d %H:%M:%S"))
+            self.assertEqual('1999-01-08 04:05:06', row.t.strftime("%Y-%m-%d %H:%M:%S"))


### PR DESCRIPTION
resolves https://github.com/crate/crate-alerts/issues/261

follow up to https://github.com/crate/crate/pull/12565

From https://www.postgresql.org/docs/current/datatype-datetime.html:

>In a literal that has been determined to be timestamp without time zone, PostgreSQL will silently ignore any time zone indication

