### PR TITLE
remove upgrade_segments usages

### DIFF
--- a/src/crate/qa/tests.py
+++ b/src/crate/qa/tests.py
@@ -126,7 +126,6 @@ def wait_for_active_shards(cursor, num_active=0, timeout=60, f=1.2):
 
 class VersionDef(NamedTuple):
     version: str
-    upgrade_segments: bool
     java_home: Iterable[str]
 
 


### PR DESCRIPTION
`upgrade_segments` is deprecated starting from CrateDB 5.1 (https://github.com/crate/crate/pull/12810/)

It seems this option was used for 1.1.x (see https://github.com/crate/crate-qa/commit/e5e2ec532299bf6e080c074617e8ec2ff94b65bf#diff-da22f73840f87231551db9d0b0f9c4592e94b91a66208f3a45935705d162a617R19)

and 2.3.x (see https://github.com/crate/crate-qa/pull/36/files#diff-da22f73840f87231551db9d0b0f9c4592e94b91a66208f3a45935705d162a617R24)

But then we removed those versions in https://github.com/crate/crate-qa/pull/84/ - so we don't need this
