### PR TITLE
Npgsql: Update to Npgsql 7

### DIFF
--- a/tests/client_tests/stock_npgsql/stock_npgsql.csproj
+++ b/tests/client_tests/stock_npgsql/stock_npgsql.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
-    <PackageReference Include="Npgsql" Version="6.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
+    <PackageReference Include="Npgsql" Version="7.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Npgsql 7 has been released [^1], and is currently at 7.0.2.

- https://www.nuget.org/packages/Npgsql/
- https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL
- https://www.nuget.org/packages/Microsoft.EntityFrameworkCore

[^1]: https://www.npgsql.org/doc/release-notes/7.0.html
