### PR TITLE
Python: Use `unittest.IsolatedAsyncioTestCase` for asyncpg and psycogp3 test cases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 ignore = E501,C901
+extend-exclude = env,.nenv*,.venv*
 
 [pycodestyle]
 ignore = E501


### PR DESCRIPTION
This patch brings [`unittest.IsolatedAsyncioTestCase`](https://docs.python.org/3/library/unittest.html#unittest.IsolatedAsyncioTestCase) to the asyncpg and psycogp3 test cases, as suggested. Thanks!