### PR TITLE
Update snapshot bwc tests from 3.3.x → 4.x.x to 4.0.x → 5.x.x

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -496,18 +496,16 @@ protocol = 'http')
 
     DROP_DOC_TABLE = 'DROP TABLE t1'
 
-    VERSION = ('3.3.x', '4.x.x')
+    VERSION = ('4.0.x', '5.x.x')
 
     def test_snapshot_compatibility(self):
-        """Test snapshot compatibility when upgrading 3.3.x -> 4.x.x
+        """Test snapshot compatibility when upgrading 4.0.x -> 5.x.x
 
         Using Minio as a S3 repository, the first cluster that runs
         creates the repo, a table and inserts/selects some data, which
         then is snapshotted and deleted. The next cluster recovers the
         data from the last snapshot, performs further inserts/selects,
         to then snapshot the data and delete it.
-
-        We are interested in the transition 3.3.x -> 4.x.x
         """
         with MinioServer() as minio:
             t = threading.Thread(target=minio.run)


### PR DESCRIPTION
3.3.x and 4.x.x are EOL. Running tests for versions that don't change
  anymore doesn't make sense.

This updates the test to cover an update from 4.0.x to 5.x.x to ensure
we keep 5.x compatible with snapshots created in 4.0
