### PR TITLE
Assert green after creating blob table in bwc tests

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -213,6 +213,7 @@ class StorageCompatibilityTest(NodeProvider, unittest.TestCase):
                 ''')
             insert_data(conn, 'doc', 't1', 10)
             c.execute(CREATE_BLOB_TABLE)
+            assert_busy(lambda: self.assert_green(conn, 'blob', 'b1'))
             run_selects(c, versions[0].version)
             container = conn.get_blob_container('b1')
             digest = container.put(BytesIO(b'sample data'))


### PR DESCRIPTION
There seems to be an issue in 4.4/4.5 where
`container.put(BytesIO(b'sample data'))` gets stuck if the shards are
not allocated.

Given that we can't fix this in those versions, this adds a check for
green after creating the table.
