### PR TITLE
Set worker count for rolling upgrade tests

### DIFF
--- a/tests/bwc/test_rolling_upgrade.py
+++ b/tests/bwc/test_rolling_upgrade.py
@@ -47,7 +47,10 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
         shards, replicas = (nodes, 1)
         expected_active_shards = shards + shards * replicas
 
-        cluster = self._new_cluster(path.from_version, nodes)
+        settings = {
+            "transport.netty.worker_count": 16
+        }
+        cluster = self._new_cluster(path.from_version, nodes, settings=settings)
         cluster.start()
         with connect(cluster.node().http_url, error_trace=True) as conn:
             c = conn.cursor()


### PR DESCRIPTION
The rolling upgrade tests are also flaky, sometimes getting stuck with a
`select count(*) from sys.shards where state = 'STARTED'` on the 4.4.0
upgrade step.

This change is mostly to rule out the threading deadlock mentioned in
https://github.com/crate/crate-qa/commit/cc3efd5ec3c24bc0fb0f7906dabc6f27462caaa1
as a reason. There are no blobs involved in the rolling upgrade, so this
likely doesn't fix it.

---

If this doesn't work out we may have to wrap `cursor.execute` calls into a thread and apply a timeout + retry.
