### PR TITLE
Bump cr8 version to 0.24.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     namespace_packages=['crate'],
     install_requires=[
         'crate',
-        'cr8>=0.21.0',
+        'cr8>=0.24.0',
         'Cython',
         'asyncpg>=0.21',
         'pyodbc',


### PR DESCRIPTION
It contains handling for maven as build system
when using source path or ``branch:<name>`` as target version.

https://github.com/mfussenegger/cr8/commit/fcd8161265bc0841058ab9f86e63eba6df6702ff


Useful for local debugging when replacing 
ROLLING_UPGRADES to smth like

```
ROLLING_UPGRADES = (
    UpgradePath('5.4.x', '/path-to-crate-repo'),
)
```
