### PR TITLE
Fix CREATE TABLE stmt used at the upgrade test

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -66,7 +66,7 @@ CREATE TABLE t1 (
     col_ip IP,
     col_timestamp TIMESTAMP,
     text STRING,
-    INDEX text_ft USING FULLTEXT(text) WITH (analyzer=myanalysis)
+    INDEX text_ft USING FULLTEXT(text) WITH (analyzer='myanalysis')
 ) CLUSTERED INTO 3 SHARDS WITH (number_of_replicas = 0)
 '''
 


### PR DESCRIPTION
Since CrateDB 5.5.0, the CREATE TABLE statement is more strict and does not allow anymore to use unqualified names in place of string literals to define values within WITH clauses. See https://cratedb.com/docs/crate/reference/en/master/appendices/release-notes/5.5.0.html#sql-statements

Relates the failure seen at #285.
