### PR TITLE
Update to pgjdbc 42.7.1

### DIFF
--- a/tests/client_tests/stock_jdbc/build.gradle
+++ b/tests/client_tests/stock_jdbc/build.gradle
@@ -9,7 +9,7 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.postgresql:postgresql:42.2.9'
+    testImplementation 'org.postgresql:postgresql:42.7.1'
     testImplementation 'org.hamcrest:hamcrest:2.1'
     testImplementation 'io.crate:crate-testing:0.11.1'
 }

--- a/tests/client_tests/stock_jdbc/src/test/java/stock_jdbc/JdbcMetaDataTest.java
+++ b/tests/client_tests/stock_jdbc/src/test/java/stock_jdbc/JdbcMetaDataTest.java
@@ -190,6 +190,8 @@ public class JdbcMetaDataTest {
     }
 
     @Test
+    @Ignore("Not supported by CrateDB after pgjdbc 42.7.0 changed the implementation")
+    // https://github.com/crate/crate/issues/15113
     public void test_getDefaultTransactionIsolation() throws Exception {
         try (var conn = DriverManager.getConnection(URL)) {
             assertThat(conn.getMetaData().getDefaultTransactionIsolation(), is(Connection.TRANSACTION_READ_COMMITTED));

--- a/tests/client_tests/stock_jdbc/src/test/java/stock_jdbc/JdbcMetaDataTest.java
+++ b/tests/client_tests/stock_jdbc/src/test/java/stock_jdbc/JdbcMetaDataTest.java
@@ -121,7 +121,8 @@ public class JdbcMetaDataTest {
         try (var conn = DriverManager.getConnection(URL)) {
             var result = conn.getMetaData().getCatalogs();
             assertThat(result.next(), is(true));
-            assertThat(result.getString(1), is("doc"));
+            // Returns `crate` as of pgjdbc 42.7.0. It returned `doc` before.
+            assertThat(result.getString(1), is("crate"));
         }
     }
 


### PR DESCRIPTION
## About

Maintenance update to use the most recent version of the [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/).
[Version 42.7.0](https://github.com/pgjdbc/pgjdbc/releases/tag/REL42.7.0) was released in November 2023. [Version 42.7.1](https://github.com/pgjdbc/pgjdbc/releases/tag/REL42.7.1) was released in December 2023. 

## References
- https://github.com/crate/cratedb-examples/pull/191
- https://github.com/crate/crate/issues/15113
