### PR TITLE
Update to Npgsql 8.0.1 and .NET 8

### DIFF
--- a/tests/client_tests/stock_npgsql/Dockerfile
+++ b/tests/client_tests/stock_npgsql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 RUN \
   apt-get update && \

--- a/tests/client_tests/stock_npgsql/run.sh
+++ b/tests/client_tests/stock_npgsql/run.sh
@@ -4,4 +4,4 @@ set -Eeuo pipefail
 
 dotnet build
 cr8 run-crate latest-nightly \
-  -- @$(pwd)/bin/Debug/net6.0/stock_npgsql {node.addresses.psql.host} {node.addresses.psql.port}
+  -- @$(pwd)/bin/Debug/net8.0/stock_npgsql {node.addresses.psql.host} {node.addresses.psql.port}

--- a/tests/client_tests/stock_npgsql/stock_npgsql.csproj
+++ b/tests/client_tests/stock_npgsql/stock_npgsql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/client_tests/stock_npgsql/stock_npgsql.csproj
+++ b/tests/client_tests/stock_npgsql/stock_npgsql.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.3" />
-    <PackageReference Include="Npgsql" Version="7.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Npgsql" Version="8.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## About

Maintenance update to use the most recent version of the [.NET data provider for PostgreSQL](https://www.npgsql.org/).
It is [version 8.0.0](https://github.com/npgsql/npgsql/releases/tag/v8.0.0), which has been released last week.
