### PR TITLE
Update to Golang 1.21

### DIFF
--- a/tests/client_tests/go/Dockerfile
+++ b/tests/client_tests/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.1
+FROM golang:1.21
 
 RUN \
   apt-get update && \


### PR DESCRIPTION
## About

Maintenance update to use the most recent stable version of Golang 1.21 for the [pgx](https://github.com/jackc/pgx) tests.
