### PR TITLE
Update to Haskell 9

### DIFF
--- a/tests/client_tests/haskell/Dockerfile
+++ b/tests/client_tests/haskell/Dockerfile
@@ -1,4 +1,4 @@
-FROM haskell:8.10
+FROM haskell:9
 
 RUN \
   apt-get update && \


### PR DESCRIPTION
## About

Maintenance update to use the most recent stable version of Haskell.
