### PR TITLE
Test 4.0.x -> latest-nightly path in test_snapshot_compatibility

### DIFF
--- a/tests/bwc/test_rolling_upgrade.py
+++ b/tests/bwc/test_rolling_upgrade.py
@@ -27,9 +27,9 @@ ROLLING_UPGRADES = (
 class RollingUpgradeTest(NodeProvider, unittest.TestCase):
 
     def test_rolling_upgrade(self):
-        print("")  # force newline for first print(path)
+        print("")  # force newline for first print
         for path in ROLLING_UPGRADES:
-            print(path)
+            print(f"From {path.from_version}")
             with self.subTest(repr(path)):
                 try:
                     self.setUp()
@@ -93,6 +93,7 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
             expected_active_shards += shards
 
         for idx, node in enumerate(cluster):
+            print(f"    upgrade node {idx} to {path.to_version}")
             new_node = self.upgrade_node(node, path.to_version)
             cluster[idx] = new_node
             with connect(new_node.http_url, error_trace=True) as conn:

--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -464,10 +464,10 @@ protocol = 'http')
 
     DROP_DOC_TABLE = 'DROP TABLE t1'
 
-    VERSION = ('4.0.x', '5.x.x')
+    VERSION = ('4.0.x', 'latest-nightly')
 
     def test_snapshot_compatibility(self):
-        """Test snapshot compatibility when upgrading 4.0.x -> 5.x.x
+        """Test snapshot compatibility when upgrading 4.0.x -> latest-nightly
 
         Using Minio as a S3 repository, the first cluster that runs
         creates the repo, a table and inserts/selects some data, which


### PR DESCRIPTION
See commits