### PR TITLE
Increase timeout per upgrade path to 15mins

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -209,7 +209,7 @@ class StorageCompatibilityTest(NodeProvider, unittest.TestCase):
                     f.truncate()
                     f.close()
 
-    @timeout(600)
+    @timeout(900)
     def _do_upgrade(self,
                     cluster: CrateCluster,
                     nodes: int,


### PR DESCRIPTION
From recently added logs it seems that the longest upgrade path, (starting with `4.0.x`), frequently consumes a bit more than 10 mins.

example failure: https://jenkins.crate.io/blue/organizations/jenkins/CrateDB%2Fqa%2Fcrate_qa/detail/crate_qa/793/pipeline