### PR TITLE
Add jenkins user to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM rust:1.72
 
 RUN \
+  groupadd jenkins && \
+  useradd -u 1001 -g jenkins -m jenkins && \
   apt-get update && \
   apt-get -y upgrade && \
   apt-get -y --no-install-recommends install openjdk-17-jdk python3-venv python3-dev
 
 ENV HOME /root
 WORKDIR /root
-USER root
+USER jenkins
 
 CMD ["bash"]

--- a/tests/client_tests/go/Dockerfile
+++ b/tests/client_tests/go/Dockerfile
@@ -1,12 +1,14 @@
 FROM golang:1.21
 
 RUN \
+  groupadd jenkins && \
+  useradd -u 1001 -g jenkins -m jenkins && \
   apt-get update && \
   apt-get -y upgrade && \
   apt-get -y install python3-venv python3-dev
 
 ENV HOME /root
 WORKDIR /root
-USER root
+USER jenkins
 
 CMD ["bash"]

--- a/tests/client_tests/haskell/Dockerfile
+++ b/tests/client_tests/haskell/Dockerfile
@@ -1,6 +1,8 @@
 FROM haskell:9
 
 RUN \
+  groupadd jenkins && \
+  useradd -u 1001 -g jenkins -m jenkins && \
   apt-get update && \
   apt-get -y install \
     libpq-dev \
@@ -10,6 +12,6 @@ RUN \
 
 ENV HOME /root
 WORKDIR /root
-USER root
+USER jenkins
 
 CMD ["/bin/bash"]

--- a/tests/client_tests/node-postgres/Dockerfile
+++ b/tests/client_tests/node-postgres/Dockerfile
@@ -1,11 +1,13 @@
 FROM node:15-buster
 
 RUN \
+  groupadd jenkins && \
+  useradd -u 1001 -g jenkins -m jenkins && \
   apt-get update && \
   apt-get -y install python3-pip libpq5 libpq-dev sudo
 
 ENV HOME /root
 WORKDIR /root
-USER ROOT
+USER jenkins
 
 CMD ["bash"]

--- a/tests/client_tests/stock_npgsql/Dockerfile
+++ b/tests/client_tests/stock_npgsql/Dockerfile
@@ -1,11 +1,13 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 RUN \
+  groupadd jenkins && \
+  useradd -u 1001 -g jenkins -m jenkins && \
   apt-get update && \
   apt-get -y install python3-venv python3-dev build-essential
 
 ENV HOME /root
 WORKDIR /root
-USER root
+USER jenkins
 
 CMD ["bash"]


### PR DESCRIPTION
Jenkins calls docker like with a user mapping to the runner's user id:

    docker run -t -d -u 1001:1001 -w ...

If the user doesn't exist in the image, the fs permissions are messed
up, which caused issues after trying to upgrade the GraalVM polyglot
package in CrateDB. See https://github.com/crate/crate/pull/15769

Adding a jenkins user to the images should fix this.
