### PR TITLE
Python: Migrate to use "implicit namespace packages" (PEP 420). Dependencies: Use crate>=1.0.0.dev2 for validation purposes. CI: Use Python 3.11, up from 3.8.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
           steps {
             checkout scm
             sh 'rm -rf env'
-            sh '/usr/bin/python3 -m venv env'
+            sh '/usr/bin/python3.11 -m venv env'
             sh 'env/bin/python -m pip install -U mypy flake8'
             sh 'find tests -name "*.py" | xargs env/bin/mypy --ignore-missing-imports'
             sh 'find src -name "*.py" | xargs env/bin/mypy --ignore-missing-imports'
@@ -27,7 +27,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3 -m venv env
+              /usr/bin/python3.11 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -41,7 +41,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3 -m venv env
+              /usr/bin/python3.11 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -55,7 +55,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3 -m venv env
+              /usr/bin/python3.11 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -69,7 +69,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3 -m venv env
+              /usr/bin/python3.11 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -83,7 +83,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3 -m venv env
+              /usr/bin/python3.11 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -97,7 +97,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3 -m venv env
+              /usr/bin/python3.11 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 
@@ -112,7 +112,7 @@ pipeline {
             checkout scm
             sh '''
               rm -rf env
-              /usr/bin/python3 -m venv env
+              /usr/bin/python3.11 -m venv env
               source env/bin/activate
               python -m pip install -U -e .
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     },
     package_dir={'': 'src'},
     packages=['crate.qa'],
-    namespace_packages=['crate'],
     install_requires=[
         'crate',
         'cr8>=0.25.0',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     package_dir={'': 'src'},
     packages=['crate.qa'],
     install_requires=[
-        'crate',
+        'crate>=1.0.0.dev2',
         'cr8>=0.25.0',
         'Cython',
         'asyncpg>=0.21',


### PR DESCRIPTION
## About
This change is part of the modernization process to migrate to modern Python namespace packages according to [PEP 420](https://peps.python.org/pep-0420/). In order to continue supporting code that has been slotted into `crate.qa`, a little update was also needed here.

## Problem
```python
ModuleNotFoundError: No module named 'crate.client'
```

## References
- https://github.com/crate/crate-python/pull/666
- https://github.com/crate/crash/pull/448

/cc @surister, @simonprickett, @kneth