### PR TITLE
5.7 -> nightly fails on select o['dyn_ignored_subcol']

### DIFF
--- a/tests/bwc/test_rolling_upgrade.py
+++ b/tests/bwc/test_rolling_upgrade.py
@@ -4,27 +4,7 @@ from crate.qa.tests import NodeProvider, insert_data, wait_for_active_shards, Up
 
 ROLLING_UPGRADES = (
     # 4.0.0 -> 4.0.1 -> 4.0.2 don't support rolling upgrades due to a bug
-    UpgradePath('4.0.2', '4.0.x'),
-    UpgradePath('4.0.x', '4.1.0'),
-    UpgradePath('4.1.0', '4.1.x'),
-    UpgradePath('4.1.x', '4.2.x'),
-    UpgradePath('4.2.x', '4.3.x'),
-    UpgradePath('4.3.x', '4.4.x'),
-    UpgradePath('4.4.x', '4.5.x'),
-    UpgradePath('4.5.x', '4.6.x'),
-    UpgradePath('4.6.x', '4.7.x'),
-    UpgradePath('4.7.x', '4.8.x'),
-    UpgradePath('4.8.x', '5.0.x'),
-    UpgradePath('5.0.x', '5.1.x'),
-    UpgradePath('5.1.x', '5.2.x'),
-    UpgradePath('5.2.x', '5.3.x'),
-    UpgradePath('5.3.x', '5.4.x'),
-    UpgradePath('5.4.x', '5.5.x'),
-    UpgradePath('5.5.x', '5.6.x'),
-    UpgradePath('5.6.x', '5.7.x'),
-    UpgradePath('5.7.x', '5.8.x'),
-    UpgradePath('5.8.x', '5.9.x'),
-    UpgradePath('5.9.x', 'latest-nightly')
+    UpgradePath('5.7.x', 'latest-nightly'),
 )
 
 


### PR DESCRIPTION
Just a proof that 5.7 -> nightly fails with 

```
FAIL: test_rolling_upgrade (test_rolling_upgrade.RollingUpgradeTest.test_rolling_upgrade) [5.7.x -> latest-nightly]

----------------------------------------------------------------------

Traceback (most recent call last):

  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa_on_pr/tests/bwc/test_rolling_upgrade.py", line 20, in test_rolling_upgrade

    self._test_rolling_upgrade(path, nodes=3)

  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa_on_pr/tests/bwc/test_rolling_upgrade.py", line 163, in _test_rolling_upgrade

    self.assertEqual(res[0][1], 'hello')

AssertionError: None != 'hello'

```

Maybe not an issue (I haven't checked it) as we are not supposed to do upgrades 5.7 -> 5.10. 

Just wanted to show that another PR https://github.com/crate/crate-qa/pull/330 can safely remove this scenario to not fail on this unrelated case 
