### PR TITLE
Increase timeout on StorageCompatibilityTest

### DIFF
--- a/tests/bwc/test_upgrade.py
+++ b/tests/bwc/test_upgrade.py
@@ -225,7 +225,7 @@ class StorageCompatibilityTest(NodeProvider, unittest.TestCase):
                     f.truncate()
                     f.close()
 
-    @timeout(1200)
+    @timeout(1800)
     def _do_upgrade(self,
                     cluster: CrateCluster,
                     nodes: int,


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

`crate-qa` periodically times out while running `test_upgrade.StorageCompatibilityTest`.

Possible fix for https://github.com/crate/crate-alerts/issues/735
