### PR TITLE
Update go docker image to 1.24

### DIFF
--- a/tests/client_tests/go/Dockerfile
+++ b/tests/client_tests/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.24
 
 RUN \
   groupadd jenkins && \


### PR DESCRIPTION
Seems to resolve the issue with missing package:
https://jenkins.crate.io/blue/organizations/jenkins/CrateDB%2Fqa%2Fcrate_qa/detail/crate_qa/1237/pipeline/39#step-198-log-148

```
# @go
=====

basic_queries.go:10:2: no required module provides package github.com/jackc/pgx/v5; to add it:
	go get github.com/jackc/pgx/v5
Failure running: go run ./basic_queries.go --hosts 127.0.0.1 --port 5432
script returned exit code 1
```