### PR TITLE
Fix Dockerfile for nodejs tests: use new format for ENV

### DIFF
--- a/tests/client_tests/node-postgres/Dockerfile
+++ b/tests/client_tests/node-postgres/Dockerfile
@@ -6,7 +6,7 @@ RUN \
   apt-get update && \
   apt-get -y install python3-pip libpq5 libpq-dev sudo
 
-ENV HOME /root
+ENV HOME=/root
 WORKDIR /root
 USER jenkins
 


### PR DESCRIPTION
```
1 warning found (use docker --debug to expand):

 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 9)

Dockerfile:3
```

See: https://jenkins.crate.io/blue/organizations/jenkins/CrateDB%2Fqa%2Fcrate_qa/detail/crate_qa/1300/pipeline/43
