### PR TITLE
Fix nodejs tests update image buster->trixie (latest debian stable)

### DIFF
--- a/tests/client_tests/node-postgres/Dockerfile
+++ b/tests/client_tests/node-postgres/Dockerfile
@@ -1,13 +1,12 @@
-FROM node:15-buster
+FROM node:24-trixie
 
 RUN \
   groupadd jenkins && \
   useradd -u 1001 -g jenkins -m jenkins && \
   apt-get update && \
-  apt-get -y install python3-pip libpq5 libpq-dev sudo
+  apt-get -y install python3-pip python3-venv libpq5 libpq-dev sudo
 
-ENV HOME=/root
-WORKDIR /root
+WORKDIR /home/jenkins
 USER jenkins
 
 CMD ["bash"]


### PR DESCRIPTION
`buster` seems to no longer be available:
```
 > [2/3] RUN   groupadd jenkins &&   useradd -u 1001 -g jenkins -m jenkins &&   apt-get update &&   apt-get -y install python3-pip libpq5 libpq-dev sudo:
0.235 Ign:1 http://security.debian.org/debian-security buster/updates InRelease
0.236 Ign:2 http://deb.debian.org/debian buster InRelease
0.282 Err:3 http://security.debian.org/debian-security buster/updates Release
0.282   404  Not Found [IP: 146.75.122.132 80]
0.283 Ign:4 http://deb.debian.org/debian buster-updates InRelease
0.309 Err:5 http://deb.debian.org/debian buster Release
0.309   404  Not Found [IP: 146.75.122.132 80]
0.332 Err:6 http://deb.debian.org/debian buster-updates Release
0.332   404  Not Found [IP: 146.75.122.132 80]
0.334 Reading package lists...
0.344 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
0.344 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.344 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
------
Dockerfile:3
--------------------
   2 |
   3 | >>> RUN \
   4 | >>>   groupadd jenkins && \
   5 | >>>   useradd -u 1001 -g jenkins -m jenkins && \
   6 | >>>   apt-get update && \
   7 | >>>   apt-get -y install python3-pip libpq5 libpq-dev sudo
   8 |
--------------------
ERROR: failed to solve: process "/bin/sh -c groupadd jenkins &&   useradd -u 1001 -g jenkins -m jenkins &&   apt-get update &&   apt-get -y install python3-pip libpq5 libpq-dev sudo" did not complete successfully: exit code: 100
```

