### PR TITLE
Add missing refresh statement

### DIFF
--- a/tests/bwc/test_rolling_upgrade.py
+++ b/tests/bwc/test_rolling_upgrade.py
@@ -192,6 +192,7 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
                     [['TABLE', 'arthur', 'crate', 'doc.t1', 'DENY', 'DQL'],
                      ['CLUSTER', 'arthur', 'crate', None, 'GRANT', 'DQL']])
 
+                c.execute("REFRESH TABLE doc.t1")
                 c.execute('''
                     SELECT type, AVG(value)
                     FROM doc.t1
@@ -286,10 +287,8 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
         # and writes into the partitioned table while upgrading were successful
         with connect(cluster.node().http_url, error_trace=True) as conn:
             c = conn.cursor()
+            c.execute("REFRESH TABLE doc.parted")
             wait_for_active_shards(c, expected_active_shards)
-            c.execute('''
-                REFRESH TABLE doc.parted
-            ''')
             c.execute('''
                 SELECT count(*)
                 FROM doc.parted


### PR DESCRIPTION
Example failure:
```
FAIL: test_rolling_upgrade_5_to_6 (test_rolling_upgrade.RollingUpgradeTest.test_rolling_upgrade_5_to_6) [6.0.x -> latest-nightly]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa/tests/bwc/test_rolling_upgrade.py", line 68, in test_rolling_upgrade_5_to_6
    self._test_rolling_upgrade(path, nodes=3)
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa/tests/bwc/test_rolling_upgrade.py", line 230, in _test_rolling_upgrade
    self.assertEqual(res[0][0], 'matchMe title')
AssertionError: 'no match title' != 'matchMe title'
- no match title
? ---
+ matchMe title
?      ++
```
