### PR TITLE
Fix connection leak in node-postgres client tests

### DIFF
--- a/tests/client_tests/node-postgres/cratedb.test.js
+++ b/tests/client_tests/node-postgres/cratedb.test.js
@@ -4,19 +4,26 @@ const Cursor = require("pg-cursor");
 let conn;
 let pool;
 
-beforeEach(async () => {
+beforeAll(() => {
   pool = new pg.Pool({
     user: "crate",
     password: "",
     host: "127.0.0.1",
     port: 5432
   })
+});
+
+afterAll(async () => {
+  await pool.end();
+});
+
+beforeEach(async () => {
   conn = await pool.connect();
   return conn;
 });
 
 afterEach(async () => {
-  conn.release();
+  await conn.release();
 });
 
 


### PR DESCRIPTION
The test emitted warnings because the connection pool wasn't closed:

    Jest did not exit one second after the test run has completed.
    'This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.

See https://node-postgres.com/apis/pool#poolend
