### PR TITLE
 Pin cr8 to 0.27.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,7 +161,7 @@ pipeline {
               test -d env && rm -rf env
               python3 -m venv env
               . env/bin/activate
-              python -m pip install -U cr8
+              python -m pip install -U cr8==0.27.2
               ./tests/client_tests/haskell/run.sh
             '''
           }
@@ -189,7 +189,7 @@ pipeline {
               test -d env && rm -rf env
               python3 -m venv env
               . env/bin/activate
-              python -m pip install -U cr8
+              python -m pip install -U cr8==0.27.2
               (cd tests/client_tests/rust/ && ./run.sh)
             '''
           }
@@ -246,7 +246,7 @@ pipeline {
               test -d env && rm -rf env
               python3 -m venv env
               . env/bin/activate
-              python -m pip install -U cr8
+              python -m pip install -U cr8==0.27.2
               (cd tests/client_tests/stock_npgsql && ./run.sh)
             '''
           }


### PR DESCRIPTION
It seems that `0.28.0` with this change: https://codeberg.org/mfussenegger/cr8/commit/62ed440b13686121da888be2bb0af7849944eff0
leads to the following error:

```
Downloading https://cdn.crate.io/downloads/releases/nightly/crate-6.1.0-2025-10-03-00-02-0e0dd73.tar.gz and extracting to /var/lib/jenkins/workspace/CrateDB/qa/crate_qa@3/.cache/cr8/crates
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa@3/env/bin/cr8", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa@3/env/lib/python3.11/site-packages/cr8/__main__.py", line 84, in main
    _run_crate_and_rest(p, args_groups)
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa@3/env/lib/python3.11/site-packages/cr8/__main__.py", line 42, in _run_crate_and_rest
    with create_node(version=args.version,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa@3/env/lib/python3.11/site-packages/cr8/run_crate.py", line 737, in create_node
    crate_dir = get_crate(version, crate_root)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa@3/env/lib/python3.11/site-packages/cr8/run_crate.py", line 709, in get_crate
    crate_dir = _download_and_extract(uri, crate_root)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa@3/env/lib/python3.11/site-packages/cr8/run_crate.py", line 497, in _download_and_extract
    t.extractall(crate_root, filter=tarfile.data_filter)
                                    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'tarfile' has no attribute 'data_filter'
```