### PR TITLE
Ensure table swaps during rolling upgrades

### DIFF
--- a/tests/bwc/test_rolling_upgrade.py
+++ b/tests/bwc/test_rolling_upgrade.py
@@ -165,6 +165,43 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
         wait_for_active_shards(c, current_shards)
         new_shards = 0
 
+        # Ensure table swaps work - the 4 swaps are equivalent to no swaps at all
+        if old_node.version >= (5, 6, 0):
+            c.execute("""
+                SELECT table_name, column_name, data_type
+                FROM information_schema.columns
+                WHERE table_schema = 'doc' AND table_name IN ('parted', 't1', 't3')
+                ORDER BY 1, 2
+            """)
+            columns = c.fetchall()
+            c.execute("""
+                SELECT table_name, number_of_shards, number_of_replicas
+                FROM information_schema.tables
+                WHERE table_schema = 'doc' AND table_name IN ('parted', 't1', 't3')
+                ORDER BY 1
+            """)
+            tables = c.fetchall()
+
+            c.execute("alter cluster swap table doc.parted to doc.t1")
+            c.execute("alter cluster swap table doc.t1 to doc.t3")
+            c.execute("alter cluster swap table doc.t3 to doc.parted")
+            c.execute("alter cluster swap table doc.t3 to doc.t1")
+
+            c.execute("""
+                SELECT table_name, column_name, data_type
+                FROM information_schema.columns
+                WHERE table_schema = 'doc' AND table_name IN ('parted', 't1', 't3')
+                ORDER BY 1, 2
+            """)
+            self.assertEqual(c.fetchall(), columns)
+            c.execute("""
+                SELECT table_name, number_of_shards, number_of_replicas
+                FROM information_schema.tables
+                WHERE table_schema = 'doc' AND table_name IN ('parted', 't1', 't3')
+                ORDER BY 1
+            """)
+            self.assertEqual(c.fetchall(), tables)
+
         c.execute("select name from sys.users order by 1")
         self.assertEqual(c.fetchall(), [["arthur"], ["crate"]])
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Adding a test for https://github.com/crate/crate/pull/18954. However, this test being added [failed](https://jenkins.crate.io/job/CrateDB/job/qa/job/crate_qa_on_pr/951/execution/node/238/log/):
```
======================================================================
FAIL: test_rolling_upgrade_5_to_6 (test_rolling_upgrade.RollingUpgradeTest.test_rolling_upgrade_5_to_6) [5.10.x -> 6.0.x]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa_on_pr/tests/bwc/test_rolling_upgrade.py", line 75, in test_rolling_upgrade_5_to_6
    self._test_rolling_upgrade(path, nodes=3)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa_on_pr/tests/bwc/test_rolling_upgrade.py", line 141, in _test_rolling_upgrade
    new_shards = self._test_queries_on_new_node(idx, c, node, new_node, nodes, shards, expected_active_shards)
  File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa_on_pr/tests/bwc/test_rolling_upgrade.py", line 213, in _test_queries_on_new_node
    self.assertEqual(c.fetchall(), columns)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Lists differ: [['pa[95 chars]', 'a', 'integer'], ['t1', 'b', 'integer'], ['[136 chars]er']] != [['pa[95 chars]', 'author', 'object'], ['t1', "author['dyn_em[284 chars]er']]

First differing element 3:
['t1', 'a', 'integer']
['t1', 'author', 'object']

Second list contains 4 additional elements.
First extra element 11:
['t3', 'a', 'integer']

Diff is 656 characters long. Set self.maxDiff to None to see it.
```

Opened a bug report, https://github.com/crate/crate/issues/18972.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #???
