### PR TITLE
Bump golang image to 1.26

### DIFF
--- a/tests/client_tests/go/Dockerfile
+++ b/tests/client_tests/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.26
 
 RUN \
   groupadd jenkins && \


### PR DESCRIPTION
go Client tests failed on CI due to latest pgx v5 update:

    go: github.com/jackc/pgx/v5@v5.9.1 requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
