### PR TITLE
[TEMP] Validate CrateDB and pgx v5.9 on GHA

### DIFF
--- a/.github/workflows/pgx.yml
+++ b/.github/workflows/pgx.yml
@@ -1,0 +1,74 @@
+name: pgx
+
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/pgx.yml'
+    - 'tests/client_tests/go/**'
+  push:
+    branches: [ main ]
+    paths:
+    - '.github/workflows/pgx.yml'
+    - 'tests/client_tests/go/**'
+  workflow_dispatch:
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  test:
+    name: "
+     Go: ${{ matrix.go-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
+     on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - 'ubuntu-latest'
+        cratedb-version:
+          - 'nightly'
+        go-version:
+          - '1.25.x'
+          - '1.26.x'
+
+    services:
+      cratedb:
+        image: crate/crate:${{ matrix.cratedb-version }}
+        ports:
+          - 4200:4200
+          - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
+
+    steps:
+
+      - name: Acquire sources
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Install project
+        run: |
+          cd tests/client_tests/go
+          go mod init cratedb.com/go-pgx-test/v2
+          go mod tidy
+
+      - name: Validate project
+        run: |
+          cd tests/client_tests/go
+          uvx crash < setup.sql
+          go run basic_queries.go --hosts localhost
+          go run bulk_operations.go --hosts localhost


### PR DESCRIPTION
## About
Trying to catch another signal where updating to pgx v5.9 goes south when integration testing on GHA, while the same test succeeds on both Jenkins (Linux) and my workstation (macOS).

```go
2026/03/23 23:31:37 pipeline: QueryStatement Bind: received unexpected message type *pgproto3.CommandComplete
```
-- [CI run #23465313608](https://github.com/crate/crate-qa/actions/runs/23465313608/job/68276112596?pr=403#step:7:29)

## Details
The same signal was first caught on the cratedb-examples repository, and we also observed integration tests on cratedb-prometheus-adapter go south, displaying a different discrepancy. All the details have been recorded in the tracking ticket [CRATEDB-CLIENTS-306](https://github.com/crate/crate-clients-tools/issues/306).

## References
- https://github.com/crate/crate-clients-tools/issues/306