### PR TITLE
Assert information_schema.routines output in rolling upgrade

### DIFF
--- a/tests/bwc/test_rolling_upgrade.py
+++ b/tests/bwc/test_rolling_upgrade.py
@@ -226,6 +226,11 @@ class RollingUpgradeTest(NodeProvider, unittest.TestCase):
         self.assertEqual(res[0][0], {'dyn_empty_array': []})
         self.assertEqual(res[0][1], 'hello')
 
+        c.execute("select routine_name from information_schema.routines where routine_type = 'FUNCTION'")
+        self.assertEqual(c.fetchall(), [
+            ["foo"],
+        ])
+
         # Ensure that inserts are working while upgrading
         c.execute(
             "INSERT INTO doc.t1 (type, value, title, author) VALUES (3, 3, 'some title', {name='nothing to see, move on'})")


### PR DESCRIPTION
This is mostly to get some more insights.

nightly crate-qa was failing recently with:

    crate.client.exceptions.ProgrammingError: UnsupportedFeatureException[Function FunctionName{schema='doc', name='foo'}(integer) is not a scalar function.]
    io.crate.exceptions.UnsupportedFeatureException: Function FunctionName{schema='doc', name='foo'}(integer) is not a scalar function.
    	at io.crate.expression.BaseImplementationSymbolVisitor.visitFunction(BaseImplementationSymbolVisitor.java:70)
    	at io.crate.expression.BaseImplementationSymbolVisitor.visitFunction(BaseImplementationSymbolVisitor.java:43)
    	at io.crate.expression.symbol.Function.accept(Function.java:243)
    	at io.crate.expression.InputFactory$Context.add(InputFactory.java:160)
    	at io.crate.execution.dml.Indexer.<init>(Indexer.java:587)
    	at io.crate.execution.dml.Indexer.<init>(Indexer.java:437)
    	at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItems(TransportShardUpsertAction.java:160)

Caused by the UDF used in the generated expression of the partitioned
table, and triggered in:

    File "/var/lib/jenkins/workspace/CrateDB/qa/crate_qa/tests/bwc/test_rolling_upgrade.py", line 234, in _test_queries_on_new_node
      c.execute("INSERT INTO doc.parted (id, value) VALUES (?, ?)", [idx + 10, idx + 10])

This adds an additional read on `information_schema.routines` before the
insert happens to see if the UDF shows up.

The `routines` table shows UDFs based on
`clusterService.state().metadata()` - so if the insert failure shows up
again while the read worked, it will be an indicator that the
`UserDefinedFunctionsService` / `Functions` are out of sync.
