### PR TITLE
Add a new validation mode "rows" to sqllogictests

### DIFF
--- a/tests/sqllogic/integtests/arithmetic.test
+++ b/tests/sqllogic/integtests/arithmetic.test
@@ -1,0 +1,60 @@
+query RRRRRRRRR rows null-args
+select round(null), ceil(null), floor(null), abs(null), sqrt(null), log(null), log(1, null), log(null, null), ln(null)
+----
+NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL
+
+
+statement ok
+create table t(d double, i integer) clustered into 1 shards with (number_of_replicas=0);
+
+statement ok        
+insert into t(d) values (1.3), (1.6), (2.2);
+
+statement ok
+refresh table t
+
+query R rowsort select-where-round
+select d from t where round(d) < 2
+----
+1.3
+
+
+query R rowsort select-where-ceil
+select d from t where ceil(d) < 3 ORDER BY 1
+----
+1.3
+1.6
+
+query I rowsort select-where-floor
+select floor(d) from t where floor(d) = 2
+----
+2
+
+statement ok
+insert into t(d, i) values (-0.2, 10)
+
+statement ok
+refresh table t;
+
+query R rowsort select-where-abs
+select abs(d) from t where abs(d) = 0.2
+----
+0.2
+
+query R rowsort select-where-ln
+select ln(i) from t where ln(i) = 2.302585092994046
+----
+2.302585092994046
+
+
+query R rowsort select-where-log
+select log(i, 100) from t where log(i, 100) = 0.5")
+----
+0.5
+
+
+query II rows select-where-log-2
+select round(d), count(*) from t where abs(d) > 1 group by 1 order by 1
+----
+1| 1
+2| 2

--- a/tests/sqllogic/sqllogictest.py
+++ b/tests/sqllogic/sqllogictest.py
@@ -110,8 +110,16 @@ class Query:
             R -> Floating point result
             T -> Text result
 
-        sort-mode is either nosort or rowsort.
-        (There is also valuesort - but this is not yet implemented)
+        sort-mode is one of nosort, rowsort, valuesort, or rows.
+
+        With nosort, rowsort, and valuesort the result is flattened to a
+        single column (one value per line), as described below.
+
+        With "rows" the result keeps its original row/column shape: each
+        expected line in the test file represents one row, and columns are
+        separated by "| ". Use this when you want to assert
+        the exact ordering of columns as returned by the query (no sorting
+        is applied to the rows in this mode).
 
         label is optional and ignored.
 
@@ -165,13 +173,33 @@ class Query:
                     hash_=hash_,
                     filename=filename
                 )
-        self.format_result(self.result)
+        if self.sort == 'rows':
+            self.format_result_rows(self.result)
+        else:
+            self.format_result(self.result)
         return partial(
             validate_cmp_result,
             expected_rows=self.result,
             query=self.query,
             filename=filename
         )
+
+    def format_result_rows(self, lines):
+        """Parse each expected line as a row of columns separated by '| '.
+
+        Unlike `format_result`, this keeps the row/column structure
+        intact so each entry in ``lines`` becomes a list of typed column
+        values matching what the cursor returns from the database.
+        """
+        for i, line in enumerate(lines):
+            cols = line.split('| ')
+            for j, col in enumerate(cols):
+                if col == 'NULL':
+                    cols[j] = 'NULL'
+                    continue
+                fmt = self.result_formats[j % len(self.result_formats)]
+                cols[j] = self.format_value(col, fmt)
+            lines[i] = cols
 
     def format_result(self, rows):
         for i, row in enumerate(rows):
@@ -209,8 +237,9 @@ class Query:
         if self.sort == 'rowsort':
             rows = sorted(rows, key=lambda row: [str(c) for c in row])
 
-        # flatten the row values for comparison
-        rows = [col for row in rows for col in row]
+        if self.sort != 'rows':
+            # flatten the row values for comparison
+            rows = [col for row in rows for col in row]
 
         if self.sort == 'valuesort':
             rows = sorted(rows, key=lambda v: str(v))

--- a/tests/sqllogic/test_sqllogic.py
+++ b/tests/sqllogic/test_sqllogic.py
@@ -17,6 +17,8 @@ project_root = dirname(dirname(here))
 
 tests_path = pathlib.Path(os.path.abspath(os.path.join(
     project_root, 'tests', 'sqllogic', 'testfiles', 'test')))
+integtests_path = pathlib.Path(os.path.abspath(os.path.join(
+    project_root, 'tests', 'sqllogic', 'integtests')))
 
 # Enable to be able to dump threads in case something gets stuck
 faulthandler.enable()
@@ -58,25 +60,36 @@ class SqlLogicTest(NodeProvider, unittest.TestCase):
         try:
             with ProcessPoolExecutor() as executor:
                 futures = []
-                for i, filename in enumerate(tests_path.glob('**/*.test')):
-                    filepath = tests_path / filename
-                    relpath = str(filepath.relative_to(tests_path))
-                    if not any(p.match(str(relpath)) for p in FILE_WHITELIST):
-                        continue
+                # The upstream sqllogic suite under testfiles/test is filtered
+                # by FILE_WHITELIST. tests under integtests/ are always run.
+                test_sources = [
+                    (tests_path, True),
+                    (integtests_path, False),
+                ]
+                i = 0
+                for path, apply_whitelist in test_sources:
+                    for filename in path.glob('**/*.test'):
+                        filepath = path / filename
+                        relpath = str(filepath.relative_to(path))
+                        if apply_whitelist and not any(
+                                p.match(str(relpath)) for p in FILE_WHITELIST):
+                            continue
 
-                    logfile = os.path.join(here, f'sqllogic-{os.path.basename(relpath)}-{i}.log')
-                    logfiles.append(logfile)
-                    future = executor.submit(
-                        run_file,
-                        filename=str(filepath),
-                        host='localhost',
-                        port=str(psql_addr.port),
-                        log_level=logging.WARNING,
-                        log_file=logfile,
-                        failfast=True,
-                        schema=f'x{i}'
-                    )
-                    futures.append(future)
+                        logfile = os.path.join(
+                            here, f'sqllogic-{os.path.basename(relpath)}-{i}.log')
+                        logfiles.append(logfile)
+                        future = executor.submit(
+                            run_file,
+                            filename=str(filepath),
+                            host='localhost',
+                            port=str(psql_addr.port),
+                            log_level=logging.WARNING,
+                            log_file=logfile,
+                            failfast=True,
+                            schema=f'x{i}'
+                        )
+                        futures.append(future)
+                        i += 1
                 for future in as_completed(futures):
                     future.result()
         finally:


### PR DESCRIPTION
The new mode validates the results rows as they are returned without splitting cols into rows and without any hashing. This is step towards implementing sqllike integ tests in crate/crate repository, so that both python tests here and Java code in crate/crate can run the same test files.

Added a sample `arithmetic.test` (derived from ArithmeticIntegrationTest`) in a new folder so that we don't need to commit those files to the `testfiles` submodule.